### PR TITLE
Propose approach to fetching pub key in appdelegate

### DIFF
--- a/custom-payment-flow/client/ios/App (ObjC)/AppDelegate.m
+++ b/custom-payment-flow/client/ios/App (ObjC)/AppDelegate.m
@@ -8,6 +8,7 @@
 
 #import "AppDelegate.h"
 #import "CheckoutViewController.h"
+@import Stripe;
 
 @implementation AppDelegate
 
@@ -21,8 +22,34 @@
     window.rootViewController = rootViewController;
     [window makeKeyAndVisible];
     self.window = window;
-
+    [self initializeStripe];
     return YES;
+}
+
+- (void)initializeStripe {
+    // Create a PaymentIntent by calling the sample server's /create-payment-intent endpoint.
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@config", @"http://127.0.0.1:4242/"]];
+//    NSMutableURLRequest *request = [[NSURLRequest requestWithURL:url] mutableCopy];
+//    [request setHTTPMethod:@"GET"];
+//    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    NSLog([url absoluteString]);
+    NSURLSessionTask *task = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *requestError) {
+        NSError *error = requestError;
+
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        NSDictionary *dataDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        if (error != nil || httpResponse.statusCode != 200 || dataDict[@"publishableKey"] == nil) {
+            NSLog(@"Failed to fetch publishableKey from /config. Check the AppDelegate.m and that your server is responding to /config");
+        }
+        else {
+            NSLog(@"Fetched publishableKey");
+            NSString *publishableKey = dataDict[@"publishableKey"];
+            // Configure the SDK with your Stripe publishable key so that it can make requests to the Stripe API
+            // For added security, our sample app gets the publishable key from the server
+            [StripeAPI setDefaultPublishableKey:publishableKey];
+        }
+    }];
+    [task resume];
 }
 
 @end

--- a/custom-payment-flow/client/ios/App (ObjC)/CheckoutViewController.m
+++ b/custom-payment-flow/client/ios/App (ObjC)/CheckoutViewController.m
@@ -14,7 +14,7 @@
 
  To run this app, follow the steps here https://github.com/stripe-samples/accept-a-card-payment#how-to-run-locally
 */
-NSString *const BackendUrl = @"http://127.0.0.1:4242/";
+NSString* const BackendUrl = @"http://127.0.0.1:4242/";
 
 @interface CheckoutViewController ()  <STPAuthenticationContext>
 
@@ -78,9 +78,7 @@ NSString *const BackendUrl = @"http://127.0.0.1:4242/";
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@create-payment-intent", BackendUrl]];
     NSDictionary *json = @{
         @"currency": @"usd",
-        @"items": @[
-                @{@"id": @"photo_subscription"}
-        ]
+        @"paymentMethodType": @"card"
     };
     NSData *body = [NSJSONSerialization dataWithJSONObject:json options:0 error:nil];
     NSMutableURLRequest *request = [[NSURLRequest requestWithURL:url] mutableCopy];
@@ -92,16 +90,12 @@ NSString *const BackendUrl = @"http://127.0.0.1:4242/";
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         NSDictionary *dataDict =[NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-        if (error != nil || httpResponse.statusCode != 200 || dataDict[@"publishableKey"] == nil) {
+        if (error != nil || httpResponse.statusCode != 200 || dataDict[@"clientSecret"] == nil) {
             [self displayAlertWithTitle:@"Error loading page" message:error.localizedDescription ?: @"" restartDemo:NO];
         }
         else {
             NSLog(@"Created PaymentIntent");
             self.paymentIntentClientSecret = dataDict[@"clientSecret"];
-            NSString *publishableKey = dataDict[@"publishableKey"];
-            // Configure the SDK with your Stripe publishable key so that it can make requests to the Stripe API
-            // For added security, our sample app gets the publishable key from the server
-            [StripeAPI setDefaultPublishableKey:publishableKey];
         }
     }];
     [task resume];

--- a/custom-payment-flow/client/ios/App (Swift)/AppDelegate.swift
+++ b/custom-payment-flow/client/ios/App (Swift)/AppDelegate.swift
@@ -7,6 +7,9 @@
 //
 
 import UIKit
+import Stripe
+
+//let BackendUrl = "http://127.0.0.1:4242/"
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -21,8 +24,31 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window.rootViewController = rootViewController
         window.makeKeyAndVisible()
         self.window = window
-
+        // Configure the SDK with your Stripe publishable key so that it can make requests to the Stripe API
+        // It's a best practice to fetch the publishable key from the server in case you need to roll the key for some reason.
+       
+        initializeStripe()
         return true
+    }
+    
+    func initializeStripe() {
+        let url = URL(string: BackendUrl + "config")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let task = URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
+            guard let response = response as? HTTPURLResponse,
+                response.statusCode == 200,
+                let data = data,
+                let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any],
+                let publishableKey = json["publishableKey"] as? String else {
+                print("Failed to retrieve publishableKey from /config")
+                return
+            }
+            print("Fetched publishable key \(publishableKey)")
+            StripeAPI.defaultPublishableKey = publishableKey
+        })
+        task.resume()
     }
 
 }

--- a/custom-payment-flow/client/ios/App (Swift)/CheckoutViewController.swift
+++ b/custom-payment-flow/client/ios/App (Swift)/CheckoutViewController.swift
@@ -69,9 +69,7 @@ class CheckoutViewController: UIViewController {
         let url = URL(string: BackendUrl + "create-payment-intent")!
         let json: [String: Any] = [
             "currency": "usd",
-            "items": [
-                ["id": "photo_subscription"]
-            ]
+            "paymentMethodType": "card"
         ]
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -82,17 +80,14 @@ class CheckoutViewController: UIViewController {
                 response.statusCode == 200,
                 let data = data,
                 let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any],
-                let clientSecret = json["clientSecret"] as? String,
-                let publishableKey = json["publishableKey"] as? String else {
+                let clientSecret = json["clientSecret"] as? String else {
                     let message = error?.localizedDescription ?? "Failed to decode response from server."
                     self?.displayAlert(title: "Error loading page", message: message)
                     return
             }
             print("Created PaymentIntent")
             self?.paymentIntentClientSecret = clientSecret
-            // Configure the SDK with your Stripe publishable key so that it can make requests to the Stripe API
-            // For added security, our sample app gets the publishable key from the server
-            StripeAPI.defaultPublishableKey = publishableKey
+            
         })
         task.resume()
     }

--- a/custom-payment-flow/client/ios/Podfile.lock
+++ b/custom-payment-flow/client/ios/Podfile.lock
@@ -1,5 +1,7 @@
 PODS:
-  - Stripe (19.4.0)
+  - Stripe (21.2.0):
+    - Stripe/Stripe3DS2 (= 21.2.0)
+  - Stripe/Stripe3DS2 (21.2.0)
 
 DEPENDENCIES:
   - Stripe
@@ -9,8 +11,8 @@ SPEC REPOS:
     - Stripe
 
 SPEC CHECKSUMS:
-  Stripe: 92f1c73a9dbd3c54277ed06a1fea6e08f20414c6
+  Stripe: 37f742a4815882db4454188664a3aa61793a12b1
 
 PODFILE CHECKSUM: 74e053ecbe24d5c0c333157a9d8e18ebf798bb90
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1


### PR DESCRIPTION
r? @davidme-stripe 
r? @thorsten-stripe 

In order to not have to re-fetch the publishableKey for any future added integration, I think we want to modify the sample so that it fetches the publishable key and any config when the app loads. This is also a best practice, I think, in case users need to roll keys they are not shipping versions of their mobile clients with pub keys hard coded.

How does this look in terms of approach? 

Should we use a global NSString for the backendURL? I wasn't sure the best way to store that so its available in both the app delegate and in the viewcontrollers.

I'd love a hand building an index view ala:

![image](https://user-images.githubusercontent.com/51129155/106327803-9655ed80-6233-11eb-9f0d-4417339a0fb8.png)

with the list of payment method types, I think that would push the individual SampleCardViewController, and SampleIdealViewController, and Sample{PMTYPE}ViewController onto the stack, then a little back button that would pop it from the stack.

1m video walkthrough of what I'm trying to explain :D 
https://drive.google.com/file/d/1p6nELPg0lYdUZE1yhfRiTcUwz3Thh-eh/view?usp=sharing