### PR TITLE
Issue-16 Centralize PaymentIntent creation logic

### DIFF
--- a/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/ApiClient.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/ApiClient.kt
@@ -1,0 +1,49 @@
+package com.example.app
+
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.IOException
+
+class ApiClient {
+    private val httpClient = OkHttpClient()
+
+    fun createPaymentIntent(
+            paymentMethodType: String,
+            completion: (paymentIntentClientSecret: String?, error: String?) -> Unit) {
+
+        val mediaType = "application/json; charset=utf-8".toMediaType()
+        val requestJson = """
+            {
+                "currency":"usd",
+                "paymentMethodType":"$paymentMethodType"
+            }
+            """
+        val body = requestJson.toRequestBody(mediaType)
+        val request = Request.Builder()
+                .url(BackendUrl + "create-payment-intent")
+                .post(body)
+                .build()
+        httpClient.newCall(request)
+                .enqueue(object: Callback {
+                    override fun onFailure(call: Call, e: IOException) {
+                        completion(null, "$e")
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        if (!response.isSuccessful) {
+                            completion(null, "$response")
+                        } else {
+                            val responseData = response.body?.string()
+                            val responseJson =
+                                    responseData?.let { JSONObject(it) } ?: JSONObject()
+
+                            // The response from the server contains the PaymentIntent's client_secret
+                            var paymentIntentClientSecret : String = responseJson.getString("clientSecret")
+                            completion(paymentIntentClientSecret, null)
+                        }
+                    }
+                })
+    }
+}

--- a/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/CardActivity.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/CardActivity.kt
@@ -14,11 +14,6 @@ import com.stripe.android.Stripe
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.view.CardInputWidget
-import okhttp3.*
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.RequestBody.Companion.toRequestBody
-import org.json.JSONObject
-import java.io.IOException
 import java.lang.ref.WeakReference
 
 
@@ -29,7 +24,6 @@ class CardActivity : AppCompatActivity() {
      *
      * To run this app, follow the steps here: https://github.com/stripe-samples/accept-a-payment#how-to-run-locally
      */
-    private val httpClient = OkHttpClient()
     private lateinit var paymentIntentClientSecret: String
     private lateinit var stripe: Stripe
 
@@ -71,45 +65,23 @@ class CardActivity : AppCompatActivity() {
     private fun startCheckout() {
         val weakActivity = WeakReference<Activity>(this)
         // Create a PaymentIntent by calling the sample server's /create-payment-intent endpoint.
-        val mediaType = "application/json; charset=utf-8".toMediaType()
-        val requestJson = """
-            {
-                "currency":"usd",
-                "paymentMethodType":"card"
-            }
-            """
-        val body = requestJson.toRequestBody(mediaType)
-        val request = Request.Builder()
-            .url(BackendUrl + "create-payment-intent")
-            .post(body)
-            .build()
-        httpClient.newCall(request)
-            .enqueue(object: Callback {
-                override fun onFailure(call: Call, e: IOException) {
-                    weakActivity.get()?.let { activity ->
-                        displayAlert(activity, "Failed to load page", "Error: $e")
-                    }
+        ApiClient().createPaymentIntent("card", completion =  {
+            paymentIntentClientSecret, error ->
+            run {
+                paymentIntentClientSecret?.let {
+                    this.paymentIntentClientSecret = it
                 }
-
-                override fun onResponse(call: Call, response: Response) {
-                    if (!response.isSuccessful) {
-                        weakActivity.get()?.let { activity ->
-                            displayAlert(
+                error?.let {
+                    weakActivity.get()?.let { activity ->
+                        displayAlert(
                                 activity,
                                 "Failed to load page",
-                                "Error: $response"
-                            )
-                        }
-                    } else {
-                        val responseData = response.body?.string()
-                        val responseJson =
-                            responseData?.let { JSONObject(it) } ?: JSONObject()
-
-                        // The response from the server contains the PaymentIntent's client_secret
-                        paymentIntentClientSecret = responseJson.getString("clientSecret")
+                                "Error: $error"
+                        )
                     }
                 }
-            })
+            }
+        })
 
         // Hook up the pay button to the card widget and stripe instance
         val payButton: Button = findViewById(R.id.payButton)


### PR DESCRIPTION
Addresses https://github.com/stripe-samples/accept-a-payment/issues/16

- Created ApiRequest class, that uses OKHttp to make API requests to local server and parses out a PaymentIntent client_secret
- CardActivity and AlipayActivity use ApiClient to create a PaymentIntent and get the client_secret or error in the callback
- Tested that both CardActivity and AlipayActivity work fine when getting an error or a valid client_secret