### PR TITLE
Fix Google-Pay PHP example "requires_action"

### DIFF
--- a/custom-payment-flow/server/php/public/apple-pay.php
+++ b/custom-payment-flow/server/php/public/apple-pay.php
@@ -72,10 +72,11 @@ try {
           // Make a call to the server to create a new
           // payment intent and store its client_secret.
           addMessage(`Client secret returned.`);
+          let clientSecret = '<?= $paymentIntent->client_secret; ?>';
 
           // Confirm the PaymentIntent without handling potential next actions (yet).
           let {error, paymentIntent} = await stripe.confirmCardPayment(
-            '<?= $paymentIntent->client_secret; ?>',
+            clientSecret,
             {
               payment_method: e.paymentMethod.id,
             },

--- a/custom-payment-flow/server/php/public/google-pay.php
+++ b/custom-payment-flow/server/php/public/google-pay.php
@@ -72,10 +72,11 @@ try {
           // Make a call to the server to create a new
           // payment intent and store its client_secret.
           addMessage(`Client secret returned.`);
+          let clientSecret = '<?= $paymentIntent->client_secret; ?>';
 
           // Confirm the PaymentIntent without handling potential next actions (yet).
           let {error, paymentIntent} = await stripe.confirmCardPayment(
-            '<?= $paymentIntent->client_secret; ?>',
+            clientSecret,
             {
               payment_method: e.paymentMethod.id,
             },


### PR DESCRIPTION
The PHP example for Google/Apple pay currently does not work if an additional action (like 3D-Secure) is required for the card. The JS variable `clientSecret` is never defined: 
https://github.com/stripe-samples/accept-a-payment/blob/4c3ddaa057631eb6d88faf6f41a67f72a62db343/custom-payment-flow/server/php/public/google-pay.php#L103-L107

This is quickly resolved by defining it earlier (can be reused for both calls).