### PR TITLE
[LATAM-2369] Add boleto to samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repository includes examples of 2 types of integration types.
 |Bacs Direct Debit| ✅ |  |
 |Bancontact| ✅ | ✅ |
 |BECS Direct Debit| | ✅ |
+|Boleto| ✅ | ✅ |
 |Cards| ✅ | ✅ |
 |EPS| ✅ | ✅ |
 |FPX| ✅ | ✅ |

--- a/custom-payment-flow/client/html/boleto.html
+++ b/custom-payment-flow/client/html/boleto.html
@@ -53,10 +53,10 @@
         </label>
         <input id="postal_code" value="01227-200" required>
 
-        <label for="address">
+        <label for="line1">
           Address
         </label>
-        <input id="address" value="Av Angelica 2491, Conjunto 91E" required>
+        <input id="line1" value="Av Angelica 2491, Conjunto 91E" required>
 
         <!-- Used to display form errors. -->
         <div id="error-message" role="alert"></div>

--- a/custom-payment-flow/client/html/boleto.html
+++ b/custom-payment-flow/client/html/boleto.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Boleto</title>
+
+    <link rel="stylesheet" href="css/base.css" />
+    <script src="https://js.stripe.com/v3/"></script>
+
+    <script src="/utils.js" defer></script>
+    <script src="/boleto.js" defer></script>
+  </head>
+  <body>
+    <main>
+      <a href="/">home</a>
+      <h1>Boleto</h1>
+
+      <form id="payment-form">
+        <label for="name">
+          Name
+        </label>
+        <input id="name" value="Jenny Rosen" required>
+
+        <label for="email">
+          Email
+        </label>
+        <input id="email" value="jr@example.com" required>
+
+        <label for="tax_id">
+          Tax id
+        </label>
+        <input id="tax_id" value="000.000.000-00" required>
+
+        <label for="country">
+          Country
+        </label>
+        <input id="country" value="BR" required>
+
+        <label for="state">
+          State
+        </label>
+        <input id="state" value="SP" required>
+
+        <label for="city">
+          City
+        </label>
+        <input id="city" value="São Paulo" required>
+
+        <label for="postal_code">
+          Postal Code
+        </label>
+        <input id="postal_code" value="01227-200" required>
+
+        <label for="address">
+          Address
+        </label>
+        <input id="address" value="Av Angelica 2491, Conjunto 91E" required>
+
+        <!-- Used to display form errors. -->
+        <div id="error-message" role="alert"></div>
+
+        <button type="submit">Pay</button>
+      </form>
+
+      <div id="messages" role="alert"></div>
+    </main>
+  </body>
+</html>

--- a/custom-payment-flow/client/html/boleto.js
+++ b/custom-payment-flow/client/html/boleto.js
@@ -1,0 +1,96 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  // Load the publishable key from the server. The publishable key
+  // is set in your .env file. In practice, most users hard code the
+  // publishable key when initializing the Stripe object.
+  const {publishableKey} = await fetch('/config').then((r) => r.json());
+  if (!publishableKey) {
+    addMessage(
+      'No publishable key returned from the server. Please check `.env` and try again'
+    );
+    alert('Please set your Stripe publishable API key in the .env file');
+  }
+
+  const stripe = Stripe(publishableKey, {
+    apiVersion: '2020-08-27',
+  });
+
+  // When the form is submitted...
+  var form = document.getElementById('payment-form');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    // Make a call to the server to create a new
+    // payment intent and store its client_secret.
+    const {error: backendError, clientSecret} = await fetch(
+      '/create-payment-intent',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          currency: 'brl',
+          paymentMethodType: 'boleto',
+        }),
+      }
+    ).then((r) => r.json());
+
+    if (backendError) {
+      addMessage(backendError.message);
+      return;
+    }
+
+    addMessage(`Client secret returned.`);
+
+    const nameInput = document.querySelector('#name');
+    const emailInput = document.querySelector('#email');
+    const taxIdInput = document.querySelector('#tax_id');
+    const countryInput = document.querySelector('#country');
+    const stateInput = document.querySelector('#state');
+    const cityInput = document.querySelector('#city');
+    const postalCodeInput = document.querySelector('#postal_code');
+    const line1Input = document.querySelector('#line1');
+    
+    // Confirm the payment given the clientSecret from the payment intent that
+    // was just created on the server.
+    const {error: stripeError, paymentIntent} = await stripe.confirmBoletoPayment(
+      clientSecret,
+      {
+        payment_method: {
+          billing_details: {
+            address: {
+              country: countryInput.value,
+              state: stateInput.value,
+              city: cityInput.value,
+              postal_code: postalCodeInput.value,
+              line1: line1Input.value,
+            },
+            name: nameInput.value,
+            email: emailInput.value,
+          },
+          boleto: {
+            tax_id: taxIdInput.value,
+          },
+        },
+      }
+    );
+
+    if (stripeError) {
+      addMessage(stripeError.message);
+      return;
+    }
+
+    addMessage(`Payment ${paymentIntent.status}: ${paymentIntent.id}`);
+
+    // When passing {any_prefix}succeed_immediately@{any_suffix}
+    // as the email address in the billing details, the payment
+    // intent will succeed after 3 seconds. We set this timeout
+    // to refetch the payment intent.
+    const i = setInterval(async () => {
+      const {paymentIntent} = await stripe.retrievePaymentIntent(clientSecret);
+      addMessage(`Payment ${paymentIntent.status}: ${paymentIntent.id}`);
+      if (paymentIntent.status === 'succeeded') {
+        clearInterval(i);
+      }
+    }, 500);
+  });
+});

--- a/custom-payment-flow/client/html/boleto.js
+++ b/custom-payment-flow/client/html/boleto.js
@@ -81,10 +81,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     addMessage(`Payment ${paymentIntent.status}: ${paymentIntent.id}`);
 
-    // When passing {any_prefix}succeed_immediately@{any_suffix}
-    // as the email address in the billing details, the payment
-    // intent will succeed after 3 seconds. We set this timeout
-    // to refetch the payment intent.
+    // From https://stripe.com/docs/payments/boleto/accept-a-payment#test-integration
+    // When passing {any_prefix}expire_with_delay@{any_domain},
+    // simulates a Boleto voucher which expires before a customer pays and the payment_intent.payment_failed webhook arrives within a minute.
+    // The expires_after field in next_action.boleto_display_details is set to about a minute in the future ,
+    // regardless of what the expires_after_days parameter in payment method options is set to.
+    // When passing {any_prefix}@{any_domain}
+    // Simulates a Boleto voucher which a customer pays immediately and the payment_intent.succeeded webhook arrives within a minute.
+    // In production, this webhook arrives after 1 business day.
     const i = setInterval(async () => {
       const {paymentIntent} = await stripe.retrievePaymentIntent(clientSecret);
       addMessage(`Payment ${paymentIntent.status}: ${paymentIntent.id}`);

--- a/custom-payment-flow/client/html/index.html
+++ b/custom-payment-flow/client/html/index.html
@@ -60,6 +60,7 @@
 
       <h3>Vouchers</h3>
       <ul>
+        <li><a href="/boleto.html">Boleto</a></li>
         <li><a href="/oxxo.html">OXXO</a></li>
       </ul>
 

--- a/custom-payment-flow/client/react-cra/src/App.js
+++ b/custom-payment-flow/client/react-cra/src/App.js
@@ -11,6 +11,7 @@ import AcssDebit from './AcssDebit';
 import ApplePay from './ApplePay';
 import Bancontact from './Bancontact';
 import BecsDebit from './BecsDebit';
+import Boleto from './Boleto';
 import Card from './Card';
 import Eps from './Eps';
 import Fpx from './Fpx';
@@ -50,6 +51,9 @@ function App(props) {
         </Route>
         <Route path="/becs-debit">
           <BecsDebit />
+        </Route>
+        <Route path="/boleto">
+          <Boleto />
         </Route>
         <Route path="/card">
           <Card />

--- a/custom-payment-flow/client/react-cra/src/Boleto.js
+++ b/custom-payment-flow/client/react-cra/src/Boleto.js
@@ -57,14 +57,14 @@ const BoletoForm = () => {
               country,
               state,
               city,
-              postalCode, // TODO probably issue
+              postal_code: postalCode,
               line1, 
             },
             name,
             email,
           },
           boleto: {
-            taxId, // TODO probably issue
+            tax_id: taxId,
           },
         },
       }
@@ -170,7 +170,7 @@ const BoletoForm = () => {
           onChange={(e) => setLine1(e.target.value)}
           required
         />
-        
+
         <button type="submit">Pay</button>
       </form>
 

--- a/custom-payment-flow/client/react-cra/src/Boleto.js
+++ b/custom-payment-flow/client/react-cra/src/Boleto.js
@@ -1,0 +1,182 @@
+import React, {useState} from 'react';
+import {withRouter} from 'react-router-dom';
+import {useStripe, useElements} from '@stripe/react-stripe-js';
+import StatusMessages, {useMessages} from './StatusMessages';
+
+const BoletoForm = () => {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [country, setCountry] = useState('BR');
+  const [state, setState] = useState('SP');
+  const [city, setCity] = useState('São Paulo');
+  const [postalCode, setPostalCode] = useState('01227-200');
+  const [line1, setLine1] = useState('Av Angelica 2491, Conjunto 91E');
+  const [name, setName] = useState('Jenny Rosen');
+  const [email, setEmail] = useState('jr@example.com');
+  const [taxId, setTaxId] = useState('000.000.000-00');
+
+  const handleSubmit = async (e) => {
+    // We don't want to let default form submission happen here,
+    // which would refresh the page.
+    e.preventDefault();
+
+    if (!stripe || !elements) {
+      // Stripe.js has not yet loaded.
+      // Make sure to disable form submission until Stripe.js has loaded.
+      addMessage('Stripe.js has not yet loaded.');
+      return;
+    }
+
+    const {error: backendError, clientSecret} = await fetch(
+      '/create-payment-intent',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          paymentMethodType: 'boleto',
+          currency: 'brl',
+        }),
+      }
+    ).then((r) => r.json());
+
+    if (backendError) {
+      addMessage(backendError.message);
+      return;
+    }
+
+    addMessage('Client secret returned');
+
+    const {error: stripeError, paymentIntent} = await stripe.confirmBoletoPayment(
+      clientSecret,
+      {
+        payment_method: {
+          billing_details: {
+            address: {
+              country,
+              state,
+              city,
+              postalCode, // TODO probably issue
+              line1, 
+            },
+            name,
+            email,
+          },
+          boleto: {
+            taxId, // TODO probably issue
+          },
+        },
+      }
+    );
+
+    if (stripeError) {
+      // Show error to your customer (e.g., insufficient funds)
+      addMessage(stripeError.message);
+      return;
+    }
+
+    // Show a success message to your customer
+    // There's a risk of the customer closing the window before callback
+    // execution. Set up a webhook or plugin to listen for the
+    // payment_intent.succeeded event that handles any business critical
+    // post-payment actions.
+    addMessage(`Payment ${paymentIntent.status}: ${paymentIntent.id}`);
+
+    // When passing {any_prefix}succeed_immediately@{any_suffix}
+    // as the email address in the billing details, the payment
+    // intent will succeed after 3 seconds. We set this timeout
+    // to refetch the payment intent.
+    const i = setInterval(async () => {
+      const {error: e, paymentIntent} = await stripe.retrievePaymentIntent(
+        clientSecret
+      );
+      addMessage(`Payment ${paymentIntent.status}: ${paymentIntent.id}`);
+      if (paymentIntent.status === 'succeeded') {
+        clearInterval(i);
+      }
+      if (e) {
+        addMessage(e.message);
+      }
+    }, 500);
+  };
+
+  return (
+    <>
+      <h1>Boleto</h1>
+
+      <form id="payment-form" onSubmit={handleSubmit}>
+        <label htmlFor="name">Name</label>
+        <input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+
+        <label htmlFor="tax_id">Tax id</label>
+        <input
+          id="tax_id"
+          value={taxId}
+          onChange={(e) => setTaxId(e.target.value)}
+          required
+        />
+
+        <label htmlFor="country">Country</label>
+        <input
+          id="country"
+          value={country}
+          onChange={(e) => setCountry(e.target.value)}
+          required
+        />
+
+        <label htmlFor="state">State</label>
+        <input
+          id="state"
+          value={state}
+          onChange={(e) => setState(e.target.value)}
+          required
+        />
+
+        <label htmlFor="city">City</label>
+        <input
+          id="city"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          required
+        />
+
+        <label htmlFor="postal_code">Postal Code</label>
+        <input
+          id="postal_code"
+          value={postalCode}
+          onChange={(e) => setPostalCode(e.target.value)}
+          required
+        />
+
+        <label htmlFor="line1">Line 1</label>
+        <input
+          id="line1"
+          value={line1}
+          onChange={(e) => setLine1(e.target.value)}
+          required
+        />
+        
+        <button type="submit">Pay</button>
+      </form>
+
+      <StatusMessages messages={messages} />
+    </>
+  );
+};
+
+export default withRouter(BoletoForm);

--- a/custom-payment-flow/client/react-cra/src/Boleto.js
+++ b/custom-payment-flow/client/react-cra/src/Boleto.js
@@ -3,7 +3,7 @@ import {withRouter} from 'react-router-dom';
 import {useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
-const BoletoForm = () => {
+const Boleto = () => {
   const stripe = useStripe();
   const elements = useElements();
   const [country, setCountry] = useState('BR');
@@ -14,6 +14,8 @@ const BoletoForm = () => {
   const [name, setName] = useState('Jenny Rosen');
   const [email, setEmail] = useState('jr@example.com');
   const [taxId, setTaxId] = useState('000.000.000-00');
+  const [messages, addMessage] = useMessages();
+
 
   const handleSubmit = async (e) => {
     // We don't want to let default form submission happen here,
@@ -179,4 +181,4 @@ const BoletoForm = () => {
   );
 };
 
-export default withRouter(BoletoForm);
+export default withRouter(Boleto);

--- a/custom-payment-flow/client/react-cra/src/List.js
+++ b/custom-payment-flow/client/react-cra/src/List.js
@@ -148,6 +148,13 @@ const List = () => {
       category: BUY_NOW_PAY_LATER,
     },
     {
+      path: 'boleto',
+      name: 'Boleto',
+      docs: 'https://stripe.com/docs/payments/boleto',
+      fact_sheet: 'https://stripe.com/payments/payment-methods-guide#boleto',
+      category: VOUCHERS,
+    },
+    {
       path: 'oxxo',
       name: 'OXXO',
       docs: 'https://stripe.com/docs/payments/oxxo',

--- a/custom-payment-flow/server/php/public/boleto.php
+++ b/custom-payment-flow/server/php/public/boleto.php
@@ -1,0 +1,143 @@
+<?php
+require_once 'shared.php';
+
+try {
+  $paymentIntent = $stripe->paymentIntents->create([
+    'payment_method_types' => ['boleto'],
+    'amount' => 5000,
+    'currency' => 'brl',
+  ]);
+} catch (\Stripe\Exception\ApiErrorException $e) {
+  http_response_code(400);
+  error_log($e->getError()->message);
+?>
+  <h1>Error</h1>
+  <p>Failed to create a PaymentIntent</p>
+  <p>Please check the server logs for more information</p>
+<?php
+  exit;
+} catch (Exception $e) {
+  error_log($e);
+  http_response_code(500);
+  exit;
+}
+?>
+
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Boleto</title>
+    <link rel="stylesheet" href="css/base.css" />
+    <script src="https://js.stripe.com/v3/"></script>
+    <script src="./utils.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
+          apiVersion: '2020-08-27',
+        });
+
+        const paymentForm = document.querySelector('#payment-form');
+        paymentForm.addEventListener('submit', async (e) => {
+          // Avoid a full page POST request.
+          e.preventDefault();
+
+          // Customer inputs
+          const nameInput = document.querySelector('#name');
+          const emailInput = document.querySelector('#email');
+          const taxIdInput = document.querySelector('#tax_id');
+          const countryInput = document.querySelector('#country');
+          const stateInput = document.querySelector('#state');
+          const cityInput = document.querySelector('#city');
+          const postalCodeInput = document.querySelector('#postal_code');
+          const line1Input = document.querySelector('#line1');
+
+          // Confirm the payment that was created server side:
+          const {error, paymentIntent} = await stripe.confirmBoletoPayment(
+            '<?= $paymentIntent->client_secret; ?>', {
+              payment_method: {
+                billing_details: {
+                  address: {
+                    country: countryInput.value,
+                    state: stateInput.value,
+                    city: cityInput.value,
+                    postal_code: postalCodeInput.value,
+                    line1: line1Input.value,
+                  },
+                  name: nameInput.value,
+                  email: emailInput.value,
+                },
+                boleto: {
+                  tax_id: taxIdInput.value,
+                },
+              },
+            }
+          );
+          if(error) {
+            addMessage(error.message);
+            return;
+          }
+          addMessage(`Payment (${paymentIntent.id}): ${paymentIntent.status}`);
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <main>
+      <a href="/">home</a>
+      <h1>Boleto</h1>
+
+      <form id="payment-form">
+        
+        <label for="name">
+          Name
+        </label>
+        <input id="name" value="Jenny Rosen" required>
+
+        <label for="email">
+          Email
+        </label>
+        <input id="email" value="jr.succeed_immediately@example.com" required>
+
+        <label for="tax_id">
+          Tax id
+        </label>
+        <input id="tax_id" value="000.000.000-00" required>
+
+        <label for="country">
+          Country
+        </label>
+        <input id="country" value="BR" required>
+
+        <label for="state">
+          State
+        </label>
+        <input id="state" value="SP" required>
+
+        <label for="city">
+          City
+        </label>
+        <input id="city" value="São Paulo" required>
+
+        <label for="postal_code">
+          Postal Code
+        </label>
+        <input id="postal_code" value="01227-200" required>
+
+        <label for="line1">
+          Address
+        </label>
+        <input id="line1" value="Av Angelica 2491, Conjunto 91E" required>
+
+        <!-- Used to display form errors. -->
+        <div id="error-message" role="alert"></div>
+
+        <button type="submit">Pay</button>
+      </form>
+
+      <div id="messages" role="alert" style="display: none;"></div>
+    </main>
+  </body>
+</html>

--- a/custom-payment-flow/server/php/public/index.php
+++ b/custom-payment-flow/server/php/public/index.php
@@ -56,6 +56,7 @@
 
       <h3>Vouchers</h3>
       <ul>
+        <li><a href="/boleto.php">Boleto</a></li>
         <li><a href="/oxxo.php">OXXO</a></li>
       </ul>
 


### PR DESCRIPTION
I tried the custom flow for php, node and python and they worked just fine
Python
![image](https://user-images.githubusercontent.com/64553760/120020457-591a2600-bfaf-11eb-88d8-40fc46067302.png)

PHP
![image](https://user-images.githubusercontent.com/64553760/120020485-63d4bb00-bfaf-11eb-821b-c9c83328b96d.png)

Node
![image](https://user-images.githubusercontent.com/64553760/120020654-a4343900-bfaf-11eb-9259-c8ea6d819a84.png)
![image](https://user-images.githubusercontent.com/64553760/120020675-aa2a1a00-bfaf-11eb-846c-723bb3c393fe.png)

React client
![image](https://user-images.githubusercontent.com/64553760/120023093-f32f9d80-bfb2-11eb-9bcd-a7252e45e0d4.png)


I also tried the checkout in python and worked perfectly
![image](https://user-images.githubusercontent.com/64553760/120020423-499add00-bfaf-11eb-8ec4-4b32b769ed6a.png)
![image](https://user-images.githubusercontent.com/64553760/120020437-50295480-bfaf-11eb-8580-58c04477b760.png)
