### PR TITLE
Add e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
 
       - name: Prepare tests
         run: |
-          echo '--format RSpec::Github::Formatter --format progress' >> .rspec
           echo "$(cat custom-payment-flow/client/react-cra/package.json | jq '.proxy = "http://web:4242"')" > custom-payment-flow/client/react-cra/package.json
           echo "$(cat prebuilt-checkout-page/client/react-cra/package.json | jq '.proxy = "http://web:4242"')" > prebuilt-checkout-page/client/react-cra/package.json
 
@@ -100,14 +99,16 @@ jobs:
           configure_docker_compose_for_integration custom-payment-flow node ../../client/html
           docker-compose --profile=e2e up -d && wait_web_server
           command="docker-compose exec -T runner bundle exec rspec spec/custom_payment_flow_e2e_spec.rb"
-          retry="${command} --only-failures"
-          $command || $retry || $retry
+          $command \
+            || $command --only-failures \
+            || $command --only-failures --format RSpec::Github::Formatter --format progress
 
           configure_docker_compose_for_integration prebuilt-checkout-page node ../../client/html
           docker-compose --profile=e2e up -d && wait_web_server
           command="docker-compose exec -T runner bundle exec rspec spec/prebuilt_checkout_page_e2e_spec.rb"
-          retry="${command} --only-failures"
-          $command || $retry || $retry
+          $command \
+            || $command --only-failures \
+            || $command --only-failures --format RSpec::Github::Formatter --format progress
 
       - name: Run tests for client/react-cra
         if: ${{ always() }}
@@ -126,14 +127,16 @@ jobs:
           configure_docker_compose_for_integration custom-payment-flow node ../../client/react-cra
           docker-compose --profile=frontend up -d && wait_web_server
           command="docker-compose exec -T runner bundle exec rspec spec/custom_payment_flow_e2e_spec.rb"
-          retry="${command} --only-failures"
-          $command || $retry || $retry
+          $command \
+            || $command --only-failures \
+            || $command --only-failures --format RSpec::Github::Formatter --format progress
 
           configure_docker_compose_for_integration prebuilt-checkout-page node ../../client/react-cra
           docker-compose --profile=frontend up -d && wait_web_server
           command="docker-compose exec -T runner bundle exec rspec spec/prebuilt_checkout_page_e2e_spec.rb"
-          retry="${command} --only-failures"
-          $command || $retry || $retry
+          $command \
+            || $command --only-failures \
+            || $command --only-failures --format RSpec::Github::Formatter --format progress
 
       - name: Collect debug information
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
-          ref: e2e # TODO: remove this
 
       - name: Setup dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   PRICE: ${{ secrets.TEST_PRICE }}
 
 jobs:
-  test:
+  server_test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -60,3 +60,83 @@ jobs:
           cat docker-compose.yml
           docker-compose ps -a
           docker-compose logs web
+
+  e2e_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'stripe-samples/sample-ci'
+          path: 'sample-ci'
+          ref: e2e # TODO: remove this
+
+      - name: Setup dependencies
+        run: |
+          source sample-ci/helpers.sh
+
+          setup_dependencies
+
+      - name: Prepare tests
+        run: |
+          echo '--format RSpec::Github::Formatter --format progress' >> .rspec
+
+      - name: Run tests for client/html
+        if: ${{ always() }}
+        env:
+          SERVER_URL: http://web:4242
+        run: |
+          source sample-ci/helpers.sh
+
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+          cat <<EOF >> .env
+          DOMAIN=${SERVER_URL}
+          PRICE=${PRICE}
+          EOF
+
+          configure_docker_compose_for_integration custom-payment-flow node ../../client/html
+          docker-compose --profile=e2e up -d && wait_web_server
+          command="docker-compose exec -T runner bundle exec rspec spec/custom_payment_flow_e2e_spec.rb"
+          retry="${command} --only-failures"
+          $command || $retry || $retry
+
+      - name: Run tests for client/react-cra
+        if: ${{ always() }}
+        env:
+          SERVER_URL: http://frontend:3000
+        run: |
+          source sample-ci/helpers.sh
+
+          echo "$(cat custom-payment-flow/client/react-cra/package.json | jq '.proxy = "http://web:4242"')" > custom-payment-flow/client/react-cra/package.json
+
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+          cat <<EOF >> .env
+          DOMAIN=${SERVER_URL}
+          PRICE=${PRICE}
+          EOF
+
+          configure_docker_compose_for_integration custom-payment-flow node ../../client/react-cra
+          docker-compose --profile=frontend up -d && wait_web_server
+          command="docker-compose exec -T runner bundle exec rspec spec/custom_payment_flow_e2e_spec.rb"
+          retry="${command} --only-failures"
+          $command || $retry || $retry
+
+      - name: Collect debug information
+        if: ${{ failure() }}
+        run: |
+          cat docker-compose.yml
+          docker-compose ps -a
+          docker-compose --profile=frontend logs web
+
+          docker cp $(docker-compose ps -qa runner | head -1):/work/tmp .
+
+      - name: Upload capybara screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshots
+          path: |
+            tmp/capybara

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,6 @@ jobs:
         run: |
           source sample-ci/helpers.sh
 
-
           install_docker_compose_settings
           export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
           cat <<EOF >> .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Prepare tests
         run: |
           echo '--format RSpec::Github::Formatter --format progress' >> .rspec
+          echo "$(cat custom-payment-flow/client/react-cra/package.json | jq '.proxy = "http://web:4242"')" > custom-payment-flow/client/react-cra/package.json
+          echo "$(cat prebuilt-checkout-page/client/react-cra/package.json | jq '.proxy = "http://web:4242"')" > prebuilt-checkout-page/client/react-cra/package.json
 
       - name: Run tests for client/html
         if: ${{ always() }}
@@ -102,6 +104,12 @@ jobs:
           retry="${command} --only-failures"
           $command || $retry || $retry
 
+          configure_docker_compose_for_integration prebuilt-checkout-page node ../../client/html
+          docker-compose --profile=e2e up -d && wait_web_server
+          command="docker-compose exec -T runner bundle exec rspec spec/prebuilt_checkout_page_e2e_spec.rb"
+          retry="${command} --only-failures"
+          $command || $retry || $retry
+
       - name: Run tests for client/react-cra
         if: ${{ always() }}
         env:
@@ -109,7 +117,6 @@ jobs:
         run: |
           source sample-ci/helpers.sh
 
-          echo "$(cat custom-payment-flow/client/react-cra/package.json | jq '.proxy = "http://web:4242"')" > custom-payment-flow/client/react-cra/package.json
 
           install_docker_compose_settings
           export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
@@ -121,6 +128,12 @@ jobs:
           configure_docker_compose_for_integration custom-payment-flow node ../../client/react-cra
           docker-compose --profile=frontend up -d && wait_web_server
           command="docker-compose exec -T runner bundle exec rspec spec/custom_payment_flow_e2e_spec.rb"
+          retry="${command} --only-failures"
+          $command || $retry || $retry
+
+          configure_docker_compose_for_integration prebuilt-checkout-page node ../../client/react-cra
+          docker-compose --profile=frontend up -d && wait_web_server
+          command="docker-compose exec -T runner bundle exec rspec spec/prebuilt_checkout_page_e2e_spec.rb"
           retry="${command} --only-failures"
           $command || $retry || $retry
 

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+spec/examples.txt

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,9 @@ gem 'rest-client'
 gem 'byebug'
 gem 'stripe'
 gem 'dotenv'
+
+gem 'selenium-webdriver'
+gem 'capybara'
+gem 'capybara-screenshot'
+
+gem 'rspec-github', require: false

--- a/custom-payment-flow/client/react-cra/package.json
+++ b/custom-payment-flow/client/react-cra/package.json
@@ -38,5 +38,5 @@
     "autoprefixer": "^9.8.0",
     "postcss-cli": "^7.1.1"
   },
-  "proxy": "http://localhost:4242"
+  "proxy": "http://web:4242"
 }

--- a/custom-payment-flow/client/react-cra/package.json
+++ b/custom-payment-flow/client/react-cra/package.json
@@ -38,5 +38,5 @@
     "autoprefixer": "^9.8.0",
     "postcss-cli": "^7.1.1"
   },
-  "proxy": "http://web:4242"
+  "proxy": "http://localhost:4242"
 }

--- a/spec/capybara_support.rb
+++ b/spec/capybara_support.rb
@@ -1,0 +1,34 @@
+require 'capybara/rspec'
+require 'selenium-webdriver'
+require 'capybara-screenshot/rspec'
+
+Capybara.server_host = Socket.ip_address_list.detect(&:ipv4_private?).ip_address
+
+Capybara.register_driver :chrome do |app|
+  opts = {browser: :chrome, url: ENV.fetch('SELENIUM_URL', 'http://selenium:4444/wd/hub')}
+  Capybara::Selenium::Driver.new(app, **opts)
+end
+
+Capybara::Screenshot.register_driver(:chrome) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
+Capybara.javascript_driver = :chrome
+Capybara.default_driver = :chrome
+Capybara.default_max_wait_time = 20
+Capybara.enable_aria_label = true
+Capybara.save_path = 'tmp/capybara'
+
+module CapybaraHelpers
+  SERVER_URL = ENV.fetch('SERVER_URL', 'http://web:4242')
+
+  def server_url(path)
+    url = URI(SERVER_URL)
+    url.path = path
+    url
+  end
+end
+
+RSpec.configure do |config|
+  config.include CapybaraHelpers
+end

--- a/spec/custom_payment_flow_e2e_spec.rb
+++ b/spec/custom_payment_flow_e2e_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe 'Custom payment flow', type: :system do
   example 'BECS Direct Debit' do
     click_on 'BECS Direct Debit'
 
+    fill_in 'name', with: 'Jenny Rosen'
+    fill_in 'email', with: 'jenny.rosen@example.com'
+
     within_frame find('iframe[name*=__privateStripeFrame][title*="input"]') do
       fill_in 'au_bsb', with: '000-000'
       fill_in 'au_bank_account_number', with: '000123456'

--- a/spec/custom_payment_flow_e2e_spec.rb
+++ b/spec/custom_payment_flow_e2e_spec.rb
@@ -1,0 +1,186 @@
+require 'capybara_support'
+
+RSpec.describe 'Custom payment flow', type: :system do
+  before do
+    visit server_url('/')
+  end
+
+  example 'Card: happy path' do
+    click_on 'Card'
+
+    within_frame find('iframe[name*=__privateStripeFrame]') do
+      fill_in 'cardnumber', with: '4242424242424242'
+      fill_in 'exp-date', with: '12 / 33'
+      fill_in 'cvc', with: '123'
+      fill_in 'postal', with: '10000'
+    end
+
+    click_on 'Pay'
+
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  example 'ACSS Debit: happy path' do
+    pending "'Payment succeeded:' does not appear"
+
+    click_on 'Pre-authorized debit in Canada (ACSS)'
+
+    click_on 'Pay'
+
+    within_frame find('iframe[name*=__privateStripeFrame]') do
+      within_frame first('iframe') do
+        click_on 'Agree'
+        find('span', text: 'Simulate successful verification').click
+        click_on 'Pay CA$19.99'
+      end
+    end
+
+    expect(page).to have_content('Payment processing')
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  # > For 'au_becs_debit' payments, we currently require your account to have a bank account in one of the following currencies: aud
+  xexample 'BECS Direct Debit' do
+  end
+
+  example 'SEPA Direct Debit: happy path' do
+    click_on 'SEPA Direct Debit'
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="input"]') do
+      fill_in 'iban', with: 'DE89370400440532013000'
+    end
+
+    click_on 'Pay'
+    expect(page).to have_content('Payment processing')
+    expect(page).to have_content(/Payment \(pi_\w+\): succeeded/)
+  end
+
+  example 'Bancontact: happy path' do
+    click_on 'Bancontact'
+
+    click_on 'Pay'
+    expect(page).to have_content('Bancontact test payment page')
+
+    click_on 'Authorize Test Payment'
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  example 'EPS: happy path' do
+    click_on 'EPS'
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="button"]') do
+      find('#bank-list-value', text: 'Select bank').click
+    end
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="list"]') do
+      find('.SelectListItem-text', text: 'Bank Austria').click
+    end
+
+    click_on 'Pay'
+    expect(page).to have_content('EPS test payment page')
+
+    click_on 'Authorize Test Payment'
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  # > This payment method is available to Stripe accounts in MY and your Stripe account is in US.
+  xexample 'FPX: happy path' do
+  end
+
+  example 'Giropay: happy path' do
+    click_on 'giropay'
+
+    click_on 'Pay'
+    expect(page).to have_content('giropay test payment page')
+
+    click_on 'Authorize Test Payment'
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  example 'iDEAL: happy path' do
+    click_on 'iDEAL'
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="button"]') do
+      find('#bank-list-value', text: 'Select bank').click
+    end
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="list"]') do
+      find('.SelectListItem-text', text: 'ING Bank').click
+    end
+
+    click_on 'Pay'
+    expect(page).to have_content('iDEAL test payment page')
+
+    click_on 'Authorize Test Payment'
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  example 'Przelewy24(P24): happy path' do
+    click_on 'Przelewy24 (P24)'
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="button"]') do
+      find('#bank-list-value', text: 'Select bank').click
+    end
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="list"]') do
+      find('.SelectListItem-text', text: 'Bank Millenium').click
+    end
+
+    click_on 'Pay'
+    expect(page).to have_content('P24 test payment page')
+
+    click_on 'Authorize Test Payment'
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  example 'Sofort: happy path' do
+    pending "'Payment succeeded:' does not appear"
+
+    click_on 'Sofort'
+
+    click_on 'Pay'
+    expect(page).to have_content('Sofort test payment page')
+
+    click_on 'Authorize Test Payment'
+    expect(page).to have_content('Payment processing')
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  example 'Afterpay / Clearpay: happy path' do
+    click_on 'Afterpay / Clearpay'
+
+    click_on 'Pay'
+    expect(page).to have_content('Afterpay Clearpay test payment page')
+
+    click_on 'Authorize Test Payment'
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  # > The payment method type "boleto" is invalid. Please ensure the provided type is activated in your dashboard (https://dashboard.stripe.com/account/payments/settings) and your account is enabled for any preview features that you are trying to use.
+  xexample 'Boleto: happy path' do
+  end
+
+  # > This payment method is available to Stripe accounts in MX and your Stripe account is in US.
+  xexample 'OXXO: happy path' do
+  end
+
+  example 'Alipay' do
+    click_on 'Alipay'
+
+    click_on 'Pay'
+    expect(page).to have_content('Alipay test payment page')
+
+    click_on 'Authorize Test Payment'
+    expect(page).to have_content('Payment succeeded')
+  end
+
+  xexample 'ApplePay: happy path' do
+  end
+
+  xexample 'Google Pay: happy path' do
+  end
+
+  # > This payment method is available to Stripe accounts in SG and MY and your Stripe account is in US.
+  xexample 'Grabpay: happy path' do
+  end
+end

--- a/spec/custom_payment_flow_e2e_spec.rb
+++ b/spec/custom_payment_flow_e2e_spec.rb
@@ -36,8 +36,17 @@ RSpec.describe 'Custom payment flow', type: :system do
     expect(page).to have_content('Payment processing')
   end
 
-  # > For 'au_becs_debit' payments, we currently require your account to have a bank account in one of the following currencies: aud
-  xexample 'BECS Direct Debit' do
+  example 'BECS Direct Debit' do
+    click_on 'BECS Direct Debit'
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="input"]') do
+      fill_in 'au_bsb', with: '000-000'
+      fill_in 'au_bank_account_number', with: '000123456'
+    end
+
+    click_on 'Pay'
+    expect(page).to have_no_content('succeeded')
+    expect(page).to have_content('we currently require your account to have a bank account in one of the following currencies: aud')
   end
 
   example 'SEPA Direct Debit: happy path' do
@@ -80,8 +89,20 @@ RSpec.describe 'Custom payment flow', type: :system do
     expect(page).to have_content('Payment succeeded')
   end
 
-  # > This payment method is available to Stripe accounts in MY and your Stripe account is in US.
-  xexample 'FPX: happy path' do
+  example 'FPX with US Stripe account' do
+    click_on 'FPX'
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="button"]') do
+      find('#fpx_bank-list-value', text: 'Select bank').click
+    end
+
+    within_frame find('iframe[name*=__privateStripeFrame][title*="list"]') do
+      find('.SelectListItem-text', text: 'Maybank2U').click
+    end
+
+    click_on 'Pay'
+    expect(page).to have_no_content('succeeded')
+    expect(page).to have_content('The payment method type provided: fpx is invalid') # This payment method is available to Stripe accounts in MY and your Stripe account is in US.'
   end
 
   example 'Giropay: happy path' do
@@ -150,12 +171,20 @@ RSpec.describe 'Custom payment flow', type: :system do
     expect(page).to have_content('Payment succeeded')
   end
 
-  # > The payment method type "boleto" is invalid. Please ensure the provided type is activated in your dashboard (https://dashboard.stripe.com/account/payments/settings) and your account is enabled for any preview features that you are trying to use.
-  xexample 'Boleto: happy path' do
+  example 'Boleto' do
+    click_on 'Boleto'
+
+    click_on 'Pay'
+    expect(page).to have_no_content('succeeded')
+    expect(page).to have_content('The payment method type "boleto" is invalid.') # Boleto is not available without an invitation yet
   end
 
-  # > This payment method is available to Stripe accounts in MX and your Stripe account is in US.
-  xexample 'OXXO: happy path' do
+  example 'OXXO' do
+    click_on 'OXXO'
+
+    click_on 'Pay'
+    expect(page).to have_no_content('succeeded')
+    expect(page).to have_content('The payment method type provided: oxxo is invalid') # This payment method is available to Stripe accounts in MX and your Stripe account is in US.
   end
 
   example 'Alipay' do
@@ -168,13 +197,28 @@ RSpec.describe 'Custom payment flow', type: :system do
     expect(page).to have_content('Payment succeeded')
   end
 
-  xexample 'ApplePay: happy path' do
+  example 'Apple Pay' do
+    click_on 'Apple Pay'
+
+    expect(page).to have_content('Before you start, you need to:')
+    expect(page).to have_content('Add a payment method to your browser.')
+    expect(page).to have_content('Serve your application over HTTPS.')
+    expect(page).to have_content('Verify your domain with Apple Pay')
   end
 
-  xexample 'Google Pay: happy path' do
+  example 'Google Pay' do
+    click_on 'Google Pay'
+
+    expect(page).to have_content('Before you start, you need to:')
+    expect(page).to have_content('Add a payment method to your browser.')
+    expect(page).to have_content('Serve your application over HTTPS.')
   end
 
-  # > This payment method is available to Stripe accounts in SG and MY and your Stripe account is in US.
-  xexample 'Grabpay: happy path' do
+  example 'GrabPay' do
+    click_on 'GrabPay'
+
+    click_on 'Pay'
+    expect(page).to have_no_content('succeeded')
+    expect(page).to have_content('The payment method type provided: grabpay is invalid') # This payment method is available to Stripe accounts in SG and MY and your Stripe account is in US.
   end
 end

--- a/spec/custom_payment_flow_e2e_spec.rb
+++ b/spec/custom_payment_flow_e2e_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe 'Custom payment flow', type: :system do
   end
 
   example 'ACSS Debit: happy path' do
-    pending "'Payment succeeded:' does not appear"
-
     click_on 'Pre-authorized debit in Canada (ACSS)'
 
     click_on 'Pay'
@@ -36,7 +34,6 @@ RSpec.describe 'Custom payment flow', type: :system do
     end
 
     expect(page).to have_content('Payment processing')
-    expect(page).to have_content('Payment succeeded')
   end
 
   # > For 'au_becs_debit' payments, we currently require your account to have a bank account in one of the following currencies: aud
@@ -134,8 +131,6 @@ RSpec.describe 'Custom payment flow', type: :system do
   end
 
   example 'Sofort: happy path' do
-    pending "'Payment succeeded:' does not appear"
-
     click_on 'Sofort'
 
     click_on 'Pay'
@@ -143,7 +138,6 @@ RSpec.describe 'Custom payment flow', type: :system do
 
     click_on 'Authorize Test Payment'
     expect(page).to have_content('Payment processing')
-    expect(page).to have_content('Payment succeeded')
   end
 
   example 'Afterpay / Clearpay: happy path' do

--- a/spec/prebuilt_checkout_page_e2e_spec.rb
+++ b/spec/prebuilt_checkout_page_e2e_spec.rb
@@ -1,0 +1,33 @@
+require 'capybara_support'
+
+RSpec.describe 'Custom payment flow', type: :system do
+  before do
+    visit server_url('/')
+  end
+
+  example 'happy path' do
+    click_on 'Buy'
+
+    fill_in 'email', with: 'test@example.com'
+    fill_in 'cardNumber', with: '4242424242424242'
+    fill_in 'cardExpiry', with: '12 / 33'
+    fill_in 'CVC', with: '123'
+    fill_in 'billingName', with: 'James McGill'
+    select 'United States', from: 'billingCountry'
+    fill_in 'billingPostalCode', with: '10000'
+
+    click_on 'Pay €10.00'
+
+    expect(page).to have_content 'Your payment succeeded'
+    expect(page).to have_content '"amount_total": 1000'
+  end
+
+  example "Cancel a payment" do
+    visit server_url('/')
+
+    click_on 'Buy'
+    click_on 'Previous page'
+
+    expect(page).to have_content 'Your payment was canceled'
+  end
+end

--- a/spec/prebuilt_checkout_page_e2e_spec.rb
+++ b/spec/prebuilt_checkout_page_e2e_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Custom payment flow', type: :system do
     expect(page).to have_content '"amount_total": 1000'
   end
 
-  example "Cancel a payment" do
+  example 'Cancel a payment' do
     visit server_url('/')
 
     click_on 'Buy'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
Test results: https://github.com/hibariya/accept-a-payment/actions

- [x] custom payment flow
  - [x] Card
  - [x] ACSS Debit
  - [x] BECS Direct Debit: cannot proceed to the payment due to the error `For 'au_becs_debit' payments, we currently require your account to have a bank account in one of the following currencies: aud`
  - [x] SEPA Direct Debit
  - [x] Bancontact
  - [x] EPS
  - [x] FPX: cannot proceed to the payment due to the error `This payment method is available to Stripe accounts in MY and your Stripe account is in US.`
  - [x] Giropay
  - [x] iDEAL
  - [x] Przelewy24(P24)
  - [x] Sofort
  - [x] Afterpay / Clearpay
  - [x] Boleto: cannot proceed to the payment due to the error `The payment method type "boleto" is invalid.`
  - [x] OXXO: cannot proceed to the payment due to the error `This payment method is available to Stripe accounts in MX and your Stripe account is in US.`
  - [x] Alipay
  - [x] Apple Pay
  - [x] Google Pay
  - [x] Grabpay: cannot proceed to the payment due to the error `This payment method is available to Stripe accounts in SG and MY and your Stripe account is in US.`
- [x] prebuilt-checkout-page