### PR TITLE
Fix two bugs in prebuilt-checkout-page

### DIFF
--- a/prebuilt-checkout-page/client/html/index.js
+++ b/prebuilt-checkout-page/client/html/index.js
@@ -24,7 +24,7 @@ submitBtn.addEventListener('click', async (e) => {
   // If the server responds with an error, display that to the user.
   if (error) {
     var displayError = document.getElementById('error-message');
-    displayError.textContent = result.error.message;
+    displayError.textContent = error;
     return;
   }
 
@@ -37,6 +37,6 @@ submitBtn.addEventListener('click', async (e) => {
   // If the redirect fails, display an error to the user.
   if (stripeError) {
     var displayError = document.getElementById('error-message');
-    displayError.textContent = result.error.message;
+    displayError.textContent = error;
   }
 });

--- a/prebuilt-checkout-page/server/python/server.py
+++ b/prebuilt-checkout-page/server/python/server.py
@@ -73,7 +73,7 @@ def create_checkout_session():
         checkout_session = stripe.checkout.Session.create(
             success_url=domain_url + '/success.html?session_id={CHECKOUT_SESSION_ID}',
             cancel_url=domain_url + '/canceled.html',
-            payment_method_types= os.getenv('PAYMENT_METHOD_TYPES').split(','),
+            payment_method_types= (os.getenv('PAYMENT_METHOD_TYPES') or 'card').split(','),
             mode='payment',
             line_items=[{
                 'price': os.getenv('PRICE'),


### PR DESCRIPTION
1. JS error handling did not match flask server response
2. flask server did not provide a default payment method in absence of
   of env var (`PAYMENT_METHOD_TYPES`). Made it match other servers
   (e.g. node) which default to `card`.