### PR TITLE
Update SEPA Debit Mandate language 

### DIFF
--- a/custom-payment-flow/client/html/sepa-debit.html
+++ b/custom-payment-flow/client/html/sepa-debit.html
@@ -49,17 +49,16 @@
 
         <!-- Display mandate acceptance text. -->
         <div id="mandate-acceptance">
-          By providing your payment information and confirming this payment,
-          you authorise (A) <strong>{{YOUR BUSINESS NAME}}</strong> and Stripe,
-          our payment service provider, to send instructions to your bank to
-          debit your account and (B) your bank to debit your account in
-          accordance with those instructions. As part of your rights, you are
-          entitled to a refund from your bank under the terms and conditions of
-          your agreement with your bank. A refund must be claimed within 8
-          weeks starting from the date on which your account was debited.  Your
-          rights are explained in a statement that you can obtain from your
-          bank. You agree to receive notifications for future debits up to 2
-          days before they occur.
+          By providing your payment information and confirming this payment, you authorise
+          (A) <strong>INSERT YOUR BUSINESS NAME HERE</strong> and Stripe,
+          our payment service provider and/or PPRO, its local service provider, to send
+          instructions to your bank to debit your account and (B) your bank to debit your
+          account in accordance with those instructions. As part of your rights, you are
+          entitled to a refund from your bank under the terms and conditions of your agreement
+          with your bank. A refund must be claimed within 8 weeks starting from the date on
+          which your account was debited. Your rights are explained in a statement that you
+          can obtain from your bank. You agree to receive notifications for future debits up
+          to 2 days before they occur.
         </div>
 
         <!-- Used to display form errors. -->

--- a/custom-payment-flow/client/react-cra/src/SepaDebit.js
+++ b/custom-payment-flow/client/react-cra/src/SepaDebit.js
@@ -125,18 +125,16 @@ const SepaDebitForm = () => {
         <div id="error-message" role="alert"></div>
 
         <div id="mandate-acceptance">
-          By providing your bank account details and confirming this payment,
-          you agree to this Direct Debit Request and the
-          <a href="https://stripe.com/au-becs-dd-service-agreement/legal">
-            Direct Debit Request service agreement
-          </a>
-          , and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343
-          Direct Debit User ID number 507156 (“Stripe”) to debit your account
-          through the Bulk Electronic Clearing System (BECS) on behalf of
-          <strong>INSERT YOUR BUSINESS NAME HERE</strong> (the "Merchant") for
-          any amounts separately communicated to you by the Merchant. You
-          certify that you are either an account holder or an authorised
-          signatory on the account listed above.
+          By providing your payment information and confirming this payment, you authorise
+          (A) <strong>INSERT YOUR BUSINESS NAME HERE</strong> and Stripe,
+          our payment service provider and/or PPRO, its local service provider, to send
+          instructions to your bank to debit your account and (B) your bank to debit your
+          account in accordance with those instructions. As part of your rights, you are
+          entitled to a refund from your bank under the terms and conditions of your agreement
+          with your bank. A refund must be claimed within 8 weeks starting from the date on
+          which your account was debited. Your rights are explained in a statement that you
+          can obtain from your bank. You agree to receive notifications for future debits up
+          to 2 days before they occur.
         </div>
       </form>
 

--- a/custom-payment-flow/server/php/public/sepa-debit.php
+++ b/custom-payment-flow/server/php/public/sepa-debit.php
@@ -130,17 +130,16 @@ try {
 
         <!-- Display mandate acceptance text. -->
         <div id="mandate-acceptance">
-          By providing your payment information and confirming this payment,
-          you authorise (A) <strong>{{YOUR BUSINESS NAME}}</strong> and Stripe,
-          our payment service provider, to send instructions to your bank to
-          debit your account and (B) your bank to debit your account in
-          accordance with those instructions. As part of your rights, you are
-          entitled to a refund from your bank under the terms and conditions of
-          your agreement with your bank. A refund must be claimed within 8
-          weeks starting from the date on which your account was debited.  Your
-          rights are explained in a statement that you can obtain from your
-          bank. You agree to receive notifications for future debits up to 2
-          days before they occur.
+          By providing your payment information and confirming this payment, you authorise
+          (A) <strong>INSERT YOUR BUSINESS NAME HERE</strong> and Stripe,
+          our payment service provider and/or PPRO, its local service provider, to send
+          instructions to your bank to debit your account and (B) your bank to debit your
+          account in accordance with those instructions. As part of your rights, you are
+          entitled to a refund from your bank under the terms and conditions of your agreement
+          with your bank. A refund must be claimed within 8 weeks starting from the date on
+          which your account was debited. Your rights are explained in a statement that you
+          can obtain from your bank. You agree to receive notifications for future debits up
+          to 2 days before they occur.
         </div>
 
         <!-- Used to display form errors. -->


### PR DESCRIPTION
Update SEPA Debit mandate language to include PPRO and match public documentation: https://stripe.com/docs/payments/sepa-debit/accept-a-payment?platform=web#add-and-configure-an-iban-element