### PR TITLE
use PaymentLauncher api to confirm payment

### DIFF
--- a/custom-payment-flow/client/android-kotlin/app/build.gradle
+++ b/custom-payment-flow/client/android-kotlin/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
 
     // Stripe Android SDK
-    implementation 'com.stripe:stripe-android:16.7.1'
+    implementation 'com.stripe:stripe-android:17.1.2'
 
     // OkHttp & GSON
     implementation 'com.squareup.okhttp3:okhttp:4.4.0'

--- a/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/CardActivity.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/CardActivity.kt
@@ -3,11 +3,13 @@ package com.example.app
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import kotlinx.android.synthetic.main.card_activity.*
+import kotlinx.coroutines.launch
 
 class CardActivity : AppCompatActivity() {
 
@@ -79,7 +81,9 @@ class CardActivity : AppCompatActivity() {
             cardInputWidget.paymentMethodCreateParams?.let { params ->
                 val confirmParams = ConfirmPaymentIntentParams
                     .createWithPaymentMethodCreateParams(params, paymentIntentClientSecret)
-                paymentLauncher.confirm(confirmParams)
+                lifecycleScope.launch {
+                    paymentLauncher.confirm(confirmParams)
+                }
             }
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The sample should be using the PaymentLauncher api rather than the Stripe object.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
PaymentLauncher is our preferred api and is significantly easier to use.  

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

![output](https://user-images.githubusercontent.com/89166418/132920331-527aeff9-563e-434f-970b-249e7c59735f.gif)
