### PR TITLE
Include Stripe Tax Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository includes examples of 2 types of integration types.
 | Small refactor to collect recurring payments. | Large refactor to collect recurring payments. |
 | Input validation and error handling built in. | Implement your own input validation and error handling. |
 | Localized in 25+ languages. | Implement your own localization. |
+| Calculate and collect sales tax, VAT, and GST with one line of code. | Implement your own logic when and how much tax to charge for. |
 
 
 ### Payment Method Type Support

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository includes examples of 2 types of integration types.
 | Small refactor to collect recurring payments. | Large refactor to collect recurring payments. |
 | Input validation and error handling built in. | Implement your own input validation and error handling. |
 | Localized in 25+ languages. | Implement your own localization. |
-| Calculate and collect sales tax, VAT, and GST with one line of code. | Implement your own logic when and how much tax to charge for. |
+| Automate calculation and collection of sales tax, VAT and GST with one line of code. | Implement your own logic to automate taxes on your transactions. |
 
 
 ### Payment Method Type Support

--- a/prebuilt-checkout-page/README.md
+++ b/prebuilt-checkout-page/README.md
@@ -94,7 +94,6 @@ after the customer completes the payment on the Checkout page.
 
 [![Required](https://img.shields.io/badge/REQUIRED-TRUE-ORANGE.svg)](https://shields.io/)
 
-
 You can create Products and Prices in the Dashboard or with the API. This
 sample requires a Price to run. Once you've created a Price, and add its ID to
 your `.env`.
@@ -107,6 +106,33 @@ You can quickly create a Price with the Stripe CLI like so:
 ```sh
 stripe prices create --unit-amount 500 --currency usd -d "product_data[name]=demo"
 ```
+
+<details>
+<summary>With Stripe Tax</summary>
+  Stripe Tax lets you calculate and collect sales tax, VAT and GST with one line of code.
+
+  Before creating a price, make sure you have Stripe Tax set up in the dashboard: [Docs - Set up Stripe Tax](https://stripe.com/docs/tax/set-up).
+
+  Stripe needs to know what kind of product you are selling to calculate the taxes. For this example we will submit a tax code describing what kind of product is used: `txcd_10000000` which is 'General - Electronically Supplied Services'. You can find a list of all tax codes here: [Available tax codes](https://stripe.com/docs/tax/tax-codes). If you leave the tax code empty, Stripe will use the default one from your [Tax settings](https://dashboard.stripe.com/test/settings/tax).
+
+  ```sh
+  stripe products create \
+    --name="demo" \
+    --tax-code="txcd_10000000"
+  ```
+
+  From the response, copy the `id` and create a price. The tax behavior can be either `inclusive` or `exclusive`. For our example, we are using `exclusive`.
+
+  ```sh
+  stripe prices create \
+    --unit-amount=500 \
+    --currency=usd \
+    --tax-behavior=exclusive \
+    --product=<INSERT_ID, like prod_ABC123>
+  ```
+
+  More Information: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
 
 Which will return the json:
 
@@ -147,7 +173,8 @@ folder README on how to run.
 For example, if you want to run the Node server:
 
 ```
-cd server/node # there's a README in this folder with instructions
+cd server/node 
+# There's a README in this folder with instructions to run the server and how to enable Stripe Tax.
 npm install
 npm start
 ```

--- a/prebuilt-checkout-page/server/dotnet/Controllers/PaymentsController.cs
+++ b/prebuilt-checkout-page/server/dotnet/Controllers/PaymentsController.cs
@@ -41,6 +41,7 @@ namespace server.Controllers
             //  [billing_address_collection] - to display billing address details on the page
             //  [customer] - if you have an existing Stripe Customer ID
             //  [customer_email] - lets you prefill the email input in the form
+            //  [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
             //  For full details see https:#stripe.com/docs/api/checkout/sessions/create
 
             //  ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
@@ -58,6 +59,7 @@ namespace server.Controllers
                         Price = this.options.Value.Price,
                     },
                 },
+                // AutomaticTax = new SessionAutomaticTaxOptions { Enabled = true },
             };
 
             var service = new SessionService(this.client);

--- a/prebuilt-checkout-page/server/dotnet/README.md
+++ b/prebuilt-checkout-page/server/dotnet/README.md
@@ -24,6 +24,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`Controllers/PaymentsController.cs`](./Controllers/PaymentsController.cs) file you will find the following code commented out
+   ```csharp
+   // AutomaticTax = new SessionAutomaticTaxOptions { Enabled = true },
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Run the application
 
 ```

--- a/prebuilt-checkout-page/server/go/README.md
+++ b/prebuilt-checkout-page/server/go/README.md
@@ -22,6 +22,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.go`](./server.go) file you will find the following code commented out
+   ```go
+   // AutomaticTax: &stripe.CheckoutSessionAutomaticTaxParams{Enabled: stripe.Bool(true)},
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Install dependencies
 
 ```

--- a/prebuilt-checkout-page/server/go/server.go
+++ b/prebuilt-checkout-page/server/go/server.go
@@ -77,6 +77,7 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 	// [customer] - if you have an existing Stripe Customer ID
 	// [payment_intent_data] - lets capture the payment later
 	// [customer_email] - lets you prefill the email input in the form
+	// [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
 	// For full details see https://stripe.com/docs/api/checkout/sessions/create
 
 	// ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID
@@ -92,6 +93,7 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 				Price:    stripe.String(os.Getenv("PRICE")),
 			},
 		},
+		// AutomaticTax: &stripe.CheckoutSessionAutomaticTaxParams{Enabled: stripe.Bool(true)},
 	}
 	s, err := session.New(params)
 	if err != nil {

--- a/prebuilt-checkout-page/server/java/README.md
+++ b/prebuilt-checkout-page/server/java/README.md
@@ -23,6 +23,18 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`Server.java`](./src/main/java/com/stripe/sample/Server.java) file you will find the following code commented out
+   ```java
+   // .setAutomaticTax(SessionCreateParams.AutomaticTax.builder().setEnabled(true).build())
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
 
 2. Build the jar
 

--- a/prebuilt-checkout-page/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/prebuilt-checkout-page/server/java/src/main/java/com/stripe/sample/Server.java
@@ -89,6 +89,7 @@ public class Server {
                 .setCancelUrl(domainUrl + "/canceled.html")
                 .addAllPaymentMethodType(paymentMethodTypes)
                 .setMode(SessionCreateParams.Mode.PAYMENT)
+                // .setAutomaticTax(SessionCreateParams.AutomaticTax.builder().setEnabled(true).build()).
                 .addLineItem(SessionCreateParams.LineItem.builder()
                         .setQuantity(1L)
                         .setPrice(price)

--- a/prebuilt-checkout-page/server/node/README.md
+++ b/prebuilt-checkout-page/server/node/README.md
@@ -22,6 +22,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.js`](./server.js) file you will find the following code commented out
+   ```js
+   // automatic_tax: { enabled: true }
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Install dependencies
 
 ```

--- a/prebuilt-checkout-page/server/node/server.js
+++ b/prebuilt-checkout-page/server/node/server.js
@@ -63,6 +63,7 @@ app.post('/create-checkout-session', async (req, res) => {
     // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
     success_url: `${domainURL}/success.html?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${domainURL}/canceled.html`,
+    // automatic_tax: { enabled: true }
   });
 
   return res.redirect(303, session.url);

--- a/prebuilt-checkout-page/server/php/README.md
+++ b/prebuilt-checkout-page/server/php/README.md
@@ -30,6 +30,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`create-checkout-session.php`](./public/create-checkout-session.php) file you will find the following code commented out
+   ```php
+   // 'automatic_tax' => ['enabled' => true],
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Install dependencies with composer
 
 From the directory that contains composer.json, run:

--- a/prebuilt-checkout-page/server/php/public/create-checkout-session.php
+++ b/prebuilt-checkout-page/server/php/public/create-checkout-session.php
@@ -20,6 +20,7 @@ $checkout_session = $stripe->checkout->sessions->create([
     // 'giropay',
   ],
   'mode' => 'payment',
+  // 'automatic_tax' => ['enabled' => true],
   'line_items' => [[
     'price' => $_ENV['PRICE'],
     'quantity' => 1,

--- a/prebuilt-checkout-page/server/python/README.md
+++ b/prebuilt-checkout-page/server/python/README.md
@@ -22,6 +22,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.py`](./server.py) file you will find the following code commented out
+   ```python
+   # automatic_tax={'enabled': True},
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Create and activate a new virtual environment
 
 **MacOS / Unix**

--- a/prebuilt-checkout-page/server/python/server.py
+++ b/prebuilt-checkout-page/server/python/server.py
@@ -65,6 +65,7 @@ def create_checkout_session():
             cancel_url=domain_url + '/canceled.html',
             payment_method_types=(os.getenv('PAYMENT_METHOD_TYPES') or 'card').split(','),
             mode='payment',
+            # automatic_tax={'enabled': True},
             line_items=[{
                 'price': os.getenv('PRICE'),
                 'quantity': 1,

--- a/prebuilt-checkout-page/server/ruby/README.md
+++ b/prebuilt-checkout-page/server/ruby/README.md
@@ -23,6 +23,19 @@ Note that `price_12345` is a placeholder and the sample will not work with that
 price ID. You can [create a price](https://stripe.com/docs/api/prices/create)
 from the dashboard or with the Stripe CLI.
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.rb`](./server.rb) file you will find the following code commented out
+   ```ruby
+   # automatic_tax: { enabled: true },
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Install dependencies
 ```
 bundle install

--- a/prebuilt-checkout-page/server/ruby/server.rb
+++ b/prebuilt-checkout-page/server/ruby/server.rb
@@ -56,6 +56,7 @@ post '/create-checkout-session' do
     cancel_url: ENV['DOMAIN'] + '/canceled.html',
     payment_method_types: pm_types,
     mode: 'payment',
+    # automatic_tax: { enabled: true },
     line_items: [{
       quantity: 1,
       price: ENV['PRICE'],


### PR DESCRIPTION
## Summary

This Pull Request is really similar to the one here: [stripe-samples/checkout-one-time-payments/pull/150](https://github.com/stripe-samples/checkout-one-time-payments/pull/150).

I have included how customers can use Stripe Tax to automatically collect taxes in their checkout.

- Added a Stripe Tax comparison in the comparison table of the main README
- Updated the `README.md` with the general set up flow, hidden below a dropdown. It explains how to create products and prices with additional properties that are needed for the automatic tax collection.
- Updated the `README.md` under each server's directory to showcase what has to be done to include Stripe Tax (simply uncomment a line of code)
- Wrote the line of code to enable Stripe Tax for each language's server and uncommented the line, so customers can enable it in an easy way

## Testing

I have tested each example manually and tax was shown when the line of code was uncommented.

## General

Thanks for using an `.env` file. It made testing a breeze 👍 

## Open Tasks

- N/A