### PR TITLE
Add E2E tests for the android-kotlin client

### DIFF
--- a/.github/workflows/android_e2e.sh
+++ b/.github/workflows/android_e2e.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+function killBackgroundJobs() {
+  kill $(jobs -p)
+}
+
+trap killBackgroundJobs EXIT
+
+export STRIPE_WEBHOOK_SECRET=$(stripe listen --api-key $STRIPE_SECRET_KEY --print-secret)
+stripe listen --forward-to http://localhost:4242/webhook &
+
+cd custom-payment-flow/server/java
+cat <<EOF >> .env
+DOMAIN="http://10.0.2.2:4242"
+PRICE="$PRICE"
+PAYMENT_METHOD_TYPES="card"
+STATIC_DIR="../../client/html"
+EOF
+mvn package
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server &
+curl -I --retry 30 --retry-delay 3 --retry-connrefused http://localhost:4242/
+cd -
+
+cd custom-payment-flow/client/android-kotlin
+./gradlew connectedAndroidTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,17 +167,27 @@ jobs:
           path: |
             tmp/capybara
 
-  android_build:
-    runs-on: ubuntu-20.04
+  e2e_android:
+    runs-on: macos-11
+    env:
+      STRIPE_API_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+      PRICE: ${{ secrets.TEST_PRICE }}
     steps:
       - uses: actions/checkout@v2
-      - name: Build
+
+      - name: Setup dependencies
         run: |
-          cd custom-payment-flow/client/android-kotlin
-          ./gradlew build
+          curl -o- -L https://github.com/stripe/stripe-cli/releases/download/v1.7.0/stripe_1.7.0_mac-os_x86_64.tar.gz | sudo tar fxz - -C /usr/local/bin
+
+      - name: Run tests
+        timeout-minutes: 10
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          script: .github/workflows/android_e2e.sh
 
   ios_build:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Build

--- a/custom-payment-flow/client/android-kotlin/app/build.gradle
+++ b/custom-payment-flow/client/android-kotlin/app/build.gradle
@@ -11,6 +11,10 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        // 10.0.2.2 is the Android emulator's alias to localhost
+        String backendUrl = System.getenv('SERVER_URL')
+        buildConfigField 'String', 'BACKEND_URL', "\"${backendUrl ?: 'http://10.0.2.2:4242/'}/\""
     }
     buildTypes {
         release {
@@ -52,4 +56,10 @@ dependencies {
     // Alipay SDK
     implementation(name:"alipaySdk-15.7.4-20200228192259", ext:"aar")
 
+    androidTestImplementation('androidx.test:core:1.4.0')
+    androidTestImplementation('androidx.test:runner:1.4.0')
+    androidTestImplementation('androidx.test:rules:1.4.0')
+    androidTestImplementation('androidx.test.ext:junit:1.1.3')
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.4.0')
+    androidTestImplementation('androidx.test.espresso:espresso-web:3.4.0')
 }

--- a/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/IdlingResourceRule.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/IdlingResourceRule.kt
@@ -1,0 +1,24 @@
+package com.example.app
+
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.idling.CountingIdlingResource
+import org.junit.rules.ExternalResource
+
+class IdlingResourceRule(name: String) : ExternalResource() {
+    private val countingResource = CountingIdlingResource(name)
+
+    override fun before() {
+        IdlingRegistry.getInstance().register(countingResource)
+        BackgroundTaskTracker.onStart = {
+            countingResource.increment()
+        }
+        BackgroundTaskTracker.onStop = {
+            countingResource.decrement()
+        }
+    }
+
+    override fun after() {
+        BackgroundTaskTracker.reset()
+        IdlingRegistry.getInstance().unregister(countingResource)
+    }
+}

--- a/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/app/AlipayActivityTest.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/app/AlipayActivityTest.kt
@@ -1,0 +1,59 @@
+package com.example.app
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
+import androidx.test.espresso.web.webdriver.Locator
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class AlipayActivityTest {
+
+    @get:Rule
+    var activityRule: ActivityScenarioRule<LauncherActivity> = ActivityScenarioRule(LauncherActivity::class.java)
+
+    @get:Rule
+    val idlingResourceRule: IdlingResourceRule = IdlingResourceRule("AlipayActivity")
+
+    @Before
+    fun launchCard() {
+        onView(withText("Alipay")).perform(click())
+        onView(withText("Alipay Activity")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun paymentWithAlipayHappyPath() {
+        onView(withText("PAY")).perform(click())
+        Thread.sleep(10000)
+        onWebView().withElement(findElement(Locator.XPATH, "//*[contains(text(),'Authorize Test Payment')]")).perform(webClick())
+        Thread.sleep(10000)
+        onView(withText("Payment succeeded")).check(matches(isDisplayed()))
+
+        onView(withText("RESTART DEMO")).perform(click())
+        onView(withText("Alipay Activity")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun paymentWithAlipayFailure() {
+        onView(withText("PAY")).perform(click())
+        Thread.sleep(10000)
+        onWebView().withElement(findElement(Locator.XPATH, "//*[contains(text(),'Fail Test Payment')]")).perform(webClick())
+        Thread.sleep(10000)
+        onView(withText("Payment failed")).check(matches(isDisplayed()))
+
+        onView(withText("OK")).perform(click())
+        onView(withText("Alipay Activity")).check(matches(isDisplayed()))
+    }
+}

--- a/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/app/CardActivityTest.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/app/CardActivityTest.kt
@@ -1,0 +1,62 @@
+package com.example.app
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withSubstring
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class CardActivityTest {
+
+    @get:Rule
+    var activityRule: ActivityScenarioRule<LauncherActivity> = ActivityScenarioRule(LauncherActivity::class.java)
+
+    @get:Rule
+    val idlingResourceRule: IdlingResourceRule = IdlingResourceRule("CardActivity")
+
+    @Before
+    fun launchCard() {
+        onView(withText("Card")).perform(click())
+        onView(withText("Card Activity")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun paymentWithCardHappyPath() {
+        onView(withId(R.id.card_number_edit_text)).perform(typeText("4242424242424242"))
+        onView(withId(R.id.expiry_date_edit_text)).perform(typeText("11/29"))
+        onView(withId(R.id.cvc_edit_text)).perform(typeText("123"))
+        onView(withId(R.id.postal_code_edit_text)).perform(typeText("10000"))
+
+        onView(withText("PAY")).perform(click())
+        onView(withText("Completed!")).check(matches(isDisplayed()))
+
+        onView(withText("RESTART DEMO")).perform(click())
+        onView(withText("Card Activity")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun paymentWithCardFailure() {
+        onView(withId(R.id.card_number_edit_text)).perform(typeText("4000000000000101"))
+        onView(withId(R.id.expiry_date_edit_text)).perform(typeText("11/29"))
+        onView(withId(R.id.cvc_edit_text)).perform(typeText("123"))
+        onView(withId(R.id.postal_code_edit_text)).perform(typeText("10000"))
+
+        onView(withText("PAY")).perform(click())
+        onView(withSubstring("Failed:")).check(matches(isDisplayed()))
+
+        onView(withText("RESTART DEMO")).perform(click())
+        onView(withText("Card Activity")).check(matches(isDisplayed()))
+    }
+}

--- a/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/BackgroundTaskTracker.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/BackgroundTaskTracker.kt
@@ -1,0 +1,11 @@
+package com.example.app
+
+internal object BackgroundTaskTracker {
+    internal var onStart: () -> Unit = {}
+    internal var onStop: () -> Unit = {}
+
+    internal fun reset() {
+        onStart = {}
+        onStop = {}
+    }
+}

--- a/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/CardActivity.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/CardActivity.kt
@@ -79,6 +79,7 @@ class CardActivity : AppCompatActivity() {
         // Confirm the PaymentIntent with the card widget
         payButton.setOnClickListener {
             cardInputWidget.paymentMethodCreateParams?.let { params ->
+                BackgroundTaskTracker.onStart()
                 val confirmParams = ConfirmPaymentIntentParams
                     .createWithPaymentMethodCreateParams(params, paymentIntentClientSecret)
                 lifecycleScope.launch {
@@ -107,5 +108,7 @@ class CardActivity : AppCompatActivity() {
             message,
             restartDemo = true
         )
+
+        BackgroundTaskTracker.onStop()
     }
 }

--- a/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/LauncherActivity.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/LauncherActivity.kt
@@ -16,7 +16,7 @@ import java.io.IOException
 import com.stripe.android.PaymentConfiguration
 
 // 10.0.2.2 is the Android emulator's alias to localhost
-val BackendUrl = "http://10.0.2.2:4242/"
+val BackendUrl = BuildConfig.BACKEND_URL
 
 class LauncherActivity : AppCompatActivity() {
 

--- a/custom-payment-flow/client/android-kotlin/app/src/main/res/xml/network_security_config.xml
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/res/xml/network_security_config.xml
@@ -2,5 +2,6 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">web</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Hello, this adds E2E tests for `custom-payment-flow/client/android-kotlin/` with Espresso.

I borrowed the `BackgroundTaskTracer` and `IdlingResourceRule` from stripe-android (introduced by https://github.com/stripe/stripe-android/pull/1908). Thanks to this synchronization mechanism,  I was able to avoid `Thread.sleep` in the tests for `CardActivity`. However, I couldn't do the same thing for `AlipayActivity`.

I also made the backend URL modifiable. This and changes in `network_security_config.xml ` are intended to support Docker environment on local machines. 