### PR TITLE
Cancel in-progress CI runs when new one triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ env:
   STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
   STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
 
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   server_test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Hello. I added the [concurrency section](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) with the `cancel-in-progress` option in the `ci.yml` to reduce unnecessary CI runs. This cancels all in-progress CI runs on the same branch before running a new one.


I confirmed this works by triggering CI twice in a short period. In the list below, the first one (bottommost) was canceled by the second one: https://github.com/hibariya/accept-a-payment/actions?query=branch%3Acancel-previous-runs
![Screenshot from 2021-10-14 21-01-27](https://user-images.githubusercontent.com/43346/137313437-89e564b9-f23d-491a-94ef-2c230a7d2f13.png)


