### PR TITLE
Improve CI settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: CI for stripe-samples/accept-a-payment
-on: [push, pull_request]
+on: [push]
 
 env:
   STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
   STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
 
 concurrency:
-  group: ci-${{ github.head_ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI for stripe-samples/accept-a-payment
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
 
 env:
   STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}


### PR DESCRIPTION
Fixes #377 

Hello. I made a couple of changes in `ci.yml` for the following reasons:

1. **Fixed the concurrency group name:** With the original group name, CI-runs on main branch would be canceled by Dependabot PRs. This change fixes that. Originally, I thought `github.head_ref` will be replaced with the branch name but it wasn't. I should have used `github.ref` instead ([about variables](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), [about concurrency](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)). 
2. **Made CI ignore Dependabot branches:** Since the secrets are not available, CI won't pass on these branches.