### PR TITLE
Update Checkout to use Dashboard Payment Method settings

### DIFF
--- a/prebuilt-checkout-page/client/html/index.html
+++ b/prebuilt-checkout-page/client/html/index.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="css/normalize.css" />
     <link rel="stylesheet" href="css/global.css" />
     <script src="https://js.stripe.com/v3/"></script>
-    <script src="./index.js" defer></script>
   </head>
 
   <body>

--- a/prebuilt-checkout-page/client/react-cra/src/components/Checkout.js
+++ b/prebuilt-checkout-page/client/react-cra/src/components/Checkout.js
@@ -19,7 +19,7 @@ const Checkout = () => {
           </div>
 
           <form action="/create-checkout-session" method="POST">
-            <button role="link">Buy</button>
+            <button id="submit" role="link">Buy</button>
           </form>
         </section>
       </div>

--- a/prebuilt-checkout-page/client/react-cra/src/css/global.css
+++ b/prebuilt-checkout-page/client/react-cra/src/css/global.css
@@ -65,7 +65,6 @@ h4 {
 .sr-main,
 .sr-content {
   display: flex;
-  flex-direction: column;
   justify-content: center;
   height: 100%;
   align-self: center;
@@ -562,4 +561,8 @@ input[type='number']::-webkit-outer-spin-button {
     opacity: 1;
     transform: scale(1);
   }
+}
+
+#submit {
+  width: 100%;
 }

--- a/prebuilt-checkout-page/server/dotnet/Configuration/StripeOptions.cs
+++ b/prebuilt-checkout-page/server/dotnet/Configuration/StripeOptions.cs
@@ -6,6 +6,5 @@ public class StripeOptions
     public string SecretKey { get; set; }
     public string WebhookSecret { get; set; }
     public string Price { get; set; }
-    public List<string> PaymentMethodTypes { get; set; }
     public string Domain { get; set; }
 }

--- a/prebuilt-checkout-page/server/dotnet/Controllers/PaymentsController.cs
+++ b/prebuilt-checkout-page/server/dotnet/Controllers/PaymentsController.cs
@@ -31,11 +31,6 @@ namespace server.Controllers
         [HttpPost("create-checkout-session")]
         public async Task<IActionResult> CreateCheckoutSession()
         {
-            // Pulled from environment variables in the `.env` file. In practice,
-            // users often hard code this list of strings representing the types of
-            // payment methods that are accepted.
-            List<string> paymentMethodTypes = this.options.Value.PaymentMethodTypes;
-
             // Create new Checkout Session for the order
             // Other optional params include:
             //  [billing_address_collection] - to display billing address details on the page
@@ -49,7 +44,6 @@ namespace server.Controllers
             {
                 SuccessUrl = $"{this.options.Value.Domain}/success.html?session_id={{CHECKOUT_SESSION_ID}}",
                 CancelUrl = $"{this.options.Value.Domain}/canceled.html",
-                PaymentMethodTypes = paymentMethodTypes,
                 Mode = "payment",
                 LineItems = new List<SessionLineItemOptions>
                 {

--- a/prebuilt-checkout-page/server/dotnet/Startup.cs
+++ b/prebuilt-checkout-page/server/dotnet/Startup.cs
@@ -44,7 +44,6 @@ namespace server
                 options.SecretKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY");
                 options.WebhookSecret = Environment.GetEnvironmentVariable("STRIPE_WEBHOOK_SECRET");
                 options.Price = Environment.GetEnvironmentVariable("PRICE");
-                options.PaymentMethodTypes = Environment.GetEnvironmentVariable("PAYMENT_METHOD_TYPES").Split(",").ToList();
                 options.Domain = Environment.GetEnvironmentVariable("DOMAIN");
             });
 

--- a/prebuilt-checkout-page/server/go/server.go
+++ b/prebuilt-checkout-page/server/go/server.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/joho/godotenv"
 	"github.com/stripe/stripe-go/v72"
@@ -69,7 +68,6 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 
 	// Pulls the list of payment method types from environment variables (`.env`).
 	// In practice, users often hard code the list of strings.
-	paymentMethodTypes := strings.Split(os.Getenv("PAYMENT_METHOD_TYPES"), ",")
 
 	// Create new Checkout Session for the order
 	// Other optional params include:
@@ -85,7 +83,6 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 	params := &stripe.CheckoutSessionParams{
 		SuccessURL:         stripe.String(domainURL + "/success.html?session_id={CHECKOUT_SESSION_ID}"),
 		CancelURL:          stripe.String(domainURL + "/canceled.html"),
-		PaymentMethodTypes: stripe.StringSlice(paymentMethodTypes),
 		Mode:               stripe.String(string(stripe.CheckoutSessionModePayment)),
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
 			{

--- a/prebuilt-checkout-page/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/prebuilt-checkout-page/server/java/src/main/java/com/stripe/sample/Server.java
@@ -2,30 +2,19 @@ package com.stripe.sample;
 
 import java.nio.file.Paths;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
-import java.util.Arrays;
-import java.util.stream.Stream;
-import java.util.stream.Collectors;
-
 import static spark.Spark.get;
 import static spark.Spark.post;
 import static spark.Spark.port;
 import static spark.Spark.staticFiles;
 
 import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
 
 import com.stripe.Stripe;
 import com.stripe.model.Event;
 import com.stripe.model.checkout.Session;
-import com.stripe.model.Price;
 import com.stripe.exception.*;
 import com.stripe.net.Webhook;
 import com.stripe.param.checkout.SessionCreateParams;
-import com.stripe.param.checkout.SessionCreateParams.LineItem;
-import com.stripe.param.checkout.SessionCreateParams.PaymentMethodType;
 
 import io.github.cdimascio.dotenv.Dotenv;
 
@@ -67,19 +56,6 @@ public class Server {
             String domainUrl = dotenv.get("DOMAIN");
             String price = dotenv.get("PRICE");
 
-            // Pull the comma separated list of payment method types from the
-            // environment variables stored in `.env`.  Then map to uppercase
-            // strings so that we can lookup the PaymentMethodType enum values.
-            //
-            // In practice, you could hard code the list of strings representing
-            // the payment method types you accept.
-            String[] pmTypes = dotenv.get("PAYMENT_METHOD_TYPES", "card").split(",", 0);
-            List<PaymentMethodType> paymentMethodTypes = Stream
-                .of(pmTypes)
-                .map(String::toUpperCase)
-                .map(PaymentMethodType::valueOf)
-                .collect(Collectors.toList());
-
             // Create new Checkout Session for the payment
             // For full details see https://stripe.com/docs/api/checkout/sessions/create
             // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID
@@ -87,7 +63,6 @@ public class Server {
             SessionCreateParams.Builder builder = new SessionCreateParams.Builder()
                 .setSuccessUrl(domainUrl + "/success.html?session_id={CHECKOUT_SESSION_ID}")
                 .setCancelUrl(domainUrl + "/canceled.html")
-                .addAllPaymentMethodType(paymentMethodTypes)
                 .setMode(SessionCreateParams.Mode.PAYMENT)
                 // .setAutomaticTax(SessionCreateParams.AutomaticTax.builder().setEnabled(true).build()).
                 .addLineItem(SessionCreateParams.LineItem.builder()

--- a/prebuilt-checkout-page/server/node/server.js
+++ b/prebuilt-checkout-page/server/node/server.js
@@ -45,16 +45,10 @@ app.get('/checkout-session', async (req, res) => {
 app.post('/create-checkout-session', async (req, res) => {
   const domainURL = process.env.DOMAIN;
 
-  // The list of supported payment method types. We fetch this from the
-  // environment variables in this sample. In practice, users often hard code a
-  // list of strings for the payment method types they plan to support.
-  const pmTypes = (process.env.PAYMENT_METHOD_TYPES || 'card').split(',').map((m) => m.trim());
-
   // Create new Checkout Session for the order
   // Other optional params include:
   // For full details see https://stripe.com/docs/api/checkout/sessions/create
   const session = await stripe.checkout.sessions.create({
-    payment_method_types: pmTypes,
     mode: 'payment',
     line_items: [{
       price: process.env.PRICE,

--- a/prebuilt-checkout-page/server/php/public/create-checkout-session.php
+++ b/prebuilt-checkout-page/server/php/public/create-checkout-session.php
@@ -12,13 +12,6 @@ $domain_url = $_ENV['DOMAIN'];
 $checkout_session = $stripe->checkout->sessions->create([
   'success_url' => $domain_url . '/success.php?session_id={CHECKOUT_SESSION_ID}',
   'cancel_url' => $domain_url . '/canceled.html',
-  'payment_method_types' => [
-    'card',
-    // 'alipay',
-    // 'ideal',
-    // 'sepa_debit',
-    // 'giropay',
-  ],
   'mode' => 'payment',
   // 'automatic_tax' => ['enabled' => true],
   'line_items' => [[

--- a/prebuilt-checkout-page/server/python/server.py
+++ b/prebuilt-checkout-page/server/python/server.py
@@ -63,7 +63,6 @@ def create_checkout_session():
         checkout_session = stripe.checkout.Session.create(
             success_url=domain_url + '/success.html?session_id={CHECKOUT_SESSION_ID}',
             cancel_url=domain_url + '/canceled.html',
-            payment_method_types=(os.getenv('PAYMENT_METHOD_TYPES') or 'card').split(','),
             mode='payment',
             # automatic_tax={'enabled': True},
             line_items=[{

--- a/prebuilt-checkout-page/server/ruby/server.rb
+++ b/prebuilt-checkout-page/server/ruby/server.rb
@@ -54,7 +54,6 @@ post '/create-checkout-session' do
     # session ID set as a query param when redirecting back to the success page.
     success_url: ENV['DOMAIN'] + '/success.html?session_id={CHECKOUT_SESSION_ID}',
     cancel_url: ENV['DOMAIN'] + '/canceled.html',
-    payment_method_types: pm_types,
     mode: 'payment',
     # automatic_tax: { enabled: true },
     line_items: [{


### PR DESCRIPTION
This updates the prebuilt checkout sample to use dashboard settings instead of `payment_method_types`. Get the CSS in the React-CRA app to align with the HTML app. 