### PR TITLE
Add Afterpay/Clearpay payment method to Android custom payment flow example

### DIFF
--- a/custom-payment-flow/client/android-kotlin/app/build.gradle
+++ b/custom-payment-flow/client/android-kotlin/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
         // 10.0.2.2 is the Android emulator's alias to localhost
         String backendUrl = System.getenv('SERVER_URL')
-        buildConfigField 'String', 'BACKEND_URL', "\"${backendUrl ?: 'http://10.0.2.2:4242/'}/\""
+        buildConfigField 'String', 'BACKEND_URL', "\"${backendUrl ?: 'http://10.0.2.2:4242'}/\""
     }
     buildTypes {
         release {

--- a/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/app/AlipayActivityTest.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/app/AlipayActivityTest.kt
@@ -28,7 +28,7 @@ class AlipayActivityTest {
     val idlingResourceRule: IdlingResourceRule = IdlingResourceRule("AlipayActivity")
 
     @Before
-    fun launchCard() {
+    fun launchAlipay() {
         onView(withText("Alipay")).perform(click())
         onView(withText("Alipay Activity")).check(matches(isDisplayed()))
     }

--- a/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/app/CardActivityTest.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/androidTest/java/com/example/app/CardActivityTest.kt
@@ -48,7 +48,7 @@ class CardActivityTest {
 
     @Test
     fun paymentWithCardFailure() {
-        onView(withId(R.id.card_number_edit_text)).perform(typeText("4000000000000101"))
+        onView(withId(R.id.card_number_edit_text)).perform(typeText("4000000000000002"))
         onView(withId(R.id.expiry_date_edit_text)).perform(typeText("11/29"))
         onView(withId(R.id.cvc_edit_text)).perform(typeText("123"))
         onView(withId(R.id.postal_code_edit_text)).perform(typeText("10000"))

--- a/custom-payment-flow/client/android-kotlin/app/src/main/AndroidManifest.xml
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/AndroidManifest.xml
@@ -35,6 +35,9 @@
         <activity
             android:name=".AlipayActivity"
             android:label="@string/alipay_activity" />
+        <activity
+            android:name=".AfterpayClearpayActivity"
+            android:label="@string/afterpay_clearpay_activity" />
     </application>
 
 </manifest>

--- a/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/AfterpayClearpayActivity.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/AfterpayClearpayActivity.kt
@@ -1,0 +1,141 @@
+package com.example.app
+
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.Address
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.payments.paymentlauncher.PaymentLauncher
+import com.stripe.android.payments.paymentlauncher.PaymentResult
+import kotlinx.android.synthetic.main.afterpay_clearpay_activity.*
+
+class AfterpayClearpayActivity : AppCompatActivity() {
+
+    /**
+     * This example collects Afterpay/Clearpay payments, implementing the guide here:
+     * https://stripe.com/docs/payments/afterpay-clearpay/accept-a-payment?platform=android
+     *
+     * To run this app, follow the steps here:
+     * https://github.com/stripe-samples/accept-a-payment#how-to-run-locally
+     */
+    private lateinit var paymentIntentClientSecret: String
+    private lateinit var paymentLauncher: PaymentLauncher
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.afterpay_clearpay_activity)
+        if(BuildConfig.DEBUG){
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
+
+        val paymentConfiguration = PaymentConfiguration.getInstance(applicationContext)
+        paymentLauncher = PaymentLauncher.Companion.create(
+            this,
+            paymentConfiguration.publishableKey,
+            paymentConfiguration.stripeAccountId,
+            ::onPaymentResult
+        )
+        startCheckout()
+    }
+
+    private fun displayAlert(
+        title: String,
+        message: String,
+        restartDemo: Boolean = false
+    ) {
+        runOnUiThread {
+            val builder = AlertDialog.Builder(this)
+                .setTitle(title)
+                .setMessage(message)
+            if (restartDemo) {
+                builder.setPositiveButton("Restart demo") { _, _ ->
+                    startCheckout()
+                }
+            }
+            else {
+                builder.setPositiveButton("Ok", null)
+            }
+            builder
+                .create()
+                .show()
+        }
+    }
+
+    private fun startCheckout() {
+        // Create a PaymentIntent by calling the sample server's /create-payment-intent endpoint.
+        ApiClient().createPaymentIntent("afterpay_clearpay", completion =  {
+            paymentIntentClientSecret, error ->
+            run {
+                paymentIntentClientSecret?.let {
+                    this.paymentIntentClientSecret = it
+                }
+                error?.let {
+                    displayAlert(
+                        "Failed to load page",
+                        "Error: $error"
+                    )
+                }
+            }
+        })
+
+        // Confirm the PaymentIntent when the user taps the pay button
+        payButton.setOnClickListener {
+            val billingDetails = PaymentMethod.BillingDetails(
+                name = "Jenny Rosen",
+                email = "jenny@rosen.com",
+                address = Address.Builder()
+                    .setLine1("1234 Market St")
+                    .setCity("San Francisco")
+                    .setState("CA")
+                    .setCountry("US")
+                    .setPostalCode("94111")
+                    .build()
+            )
+
+            val shippingDetails = ConfirmPaymentIntentParams.Shipping(
+                name = "Jenny Rosen",
+                address = Address.Builder()
+                    .setLine1("1234 Market St")
+                    .setCity("San Francisco")
+                    .setState("CA")
+                    .setCountry("US")
+                    .setPostalCode("94111")
+                    .build()
+            )
+
+            val paymentMethodCreateParams = PaymentMethodCreateParams.createAfterpayClearpay(billingDetails)
+            val confirmParams = ConfirmPaymentIntentParams
+                .createWithPaymentMethodCreateParams(
+                    paymentMethodCreateParams = paymentMethodCreateParams,
+                    clientSecret = paymentIntentClientSecret,
+                    shipping = shippingDetails
+                )
+            paymentLauncher.confirm(confirmParams)
+        }
+    }
+
+    private fun onPaymentResult(paymentResult: PaymentResult) {
+        val message = when (paymentResult) {
+            is PaymentResult.Completed -> {
+                "Completed!"
+            }
+            is PaymentResult.Canceled -> {
+                "Canceled!"
+            }
+            is PaymentResult.Failed -> {
+                // This string comes from the PaymentIntent's error message.
+                // See here: https://stripe.com/docs/api/payment_intents/object#payment_intent_object-last_payment_error-message
+                "Failed: " + paymentResult.throwable.message
+            }
+        }
+        displayAlert(
+            "Payment Result:",
+            message,
+            restartDemo = true
+        )
+    }
+}

--- a/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/LauncherActivity.kt
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/java/com/example/app/LauncherActivity.kt
@@ -88,7 +88,8 @@ class LauncherActivity : AppCompatActivity() {
 
         private val items = listOf(
             PaymentMethodItem(activity.getString(R.string.card_item), CardActivity::class.java),
-            PaymentMethodItem(activity.getString(R.string.alipay_item), AlipayActivity::class.java)
+            PaymentMethodItem(activity.getString(R.string.alipay_item), AlipayActivity::class.java),
+            PaymentMethodItem(activity.getString(R.string.afterpay_clearpay_item), AfterpayClearpayActivity::class.java)
         )
 
         private data class PaymentMethodItem constructor(val text: String, val activityClass: Class<*>)

--- a/custom-payment-flow/client/android-kotlin/app/src/main/res/layout/afterpay_clearpay_activity.xml
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/res/layout/afterpay_clearpay_activity.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="20dp"
+    tools:context=".AfterpayClearpayActivity"
+    tools:showIn="@layout/afterpay_clearpay_activity">
+
+    <Button
+        android:text="@string/pay"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/payButton"
+        android:layout_marginTop="20dp"
+        android:backgroundTint="@android:color/holo_green_light"/>
+
+</LinearLayout>

--- a/custom-payment-flow/client/android-kotlin/app/src/main/res/values/strings.xml
+++ b/custom-payment-flow/client/android-kotlin/app/src/main/res/values/strings.xml
@@ -2,8 +2,10 @@
     <string name="app_name">App</string>
     <string name="card_activity">Card Activity</string>
     <string name="alipay_activity">Alipay Activity</string>
+    <string name="afterpay_clearpay_activity">Afterpay/Clearpay Activity</string>
     <string name="action_settings">Settings</string>
     <string name="pay">Pay</string>
     <string name="card_item">Card</string>
     <string name="alipay_item">Alipay</string>
+    <string name="afterpay_clearpay_item">Afterpay/Clearpay</string>
 </resources>


### PR DESCRIPTION
This PR adds an example integration of Afterpay/Clearpay to the `android-kotlin` client for custom payment flows.

There are also some small corrections for the fallback backend URL (duplicate trailing `/`) and existing tests.