### PR TITLE
Update to include vue-cva as option in stripe CLI

### DIFF
--- a/.cli.json
+++ b/.cli.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "prebuilt-checkout-page",
-      "clients": ["html", "react-cra"],
+      "clients": ["html", "react-cra", "vue-cva"],
       "servers": [
         "ruby",
         "node",

--- a/prebuilt-checkout-page/README.md
+++ b/prebuilt-checkout-page/README.md
@@ -48,6 +48,7 @@ Pick a client:
 
 - [html](./client/html)
 - [react-cra](./client/react-cra) (React with create-react-app)
+- [vue-cva](./client/vue-cva)  (React with Create Vite App)
 
 
 **Installing and cloning manually**


### PR DESCRIPTION
Allows selecting vue-cva client as an option when running `stripe samples create accept-a-payment`