### PR TITLE
Enable dependabot for react and vue clients

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,23 @@ updates:
     directory: "/prebuilt-checkout-page/server/node/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/custom-payment-flow/client/react-cra/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/payment-element/client/react-cra/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/prebuilt-checkout-page/client/react-cra/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/prebuilt-checkout-page/client/vue-cva/"
+    schedule:
+      interval: "weekly"
+
 
   # go dependencies
   - package-ecosystem: "gomod"


### PR DESCRIPTION
cc @charlesw-stripe 

Heads up that I'm going to enable dependabot for the vue client. This should open PRs when there are new dependencies available for the react and vue clients. I may need a hand reviewing some of the vue ones :) 