### PR TITLE
Migrate to react-router v6

### DIFF
--- a/custom-payment-flow/client/react-cra/src/AcssDebit.js
+++ b/custom-payment-flow/client/react-cra/src/AcssDebit.js
@@ -1,5 +1,4 @@
 import React, {useState} from 'react';
-import {withRouter} from 'react-router-dom';
 import {
   useStripe,
   useElements,
@@ -120,4 +119,4 @@ const AcssDebitForm = () => {
   );
 };
 
-export default withRouter(AcssDebitForm);
+export default AcssDebitForm;

--- a/custom-payment-flow/client/react-cra/src/AfterpayClearpay.js
+++ b/custom-payment-flow/client/react-cra/src/AfterpayClearpay.js
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react'
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {useStripe} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -230,4 +230,4 @@ const AfterpayClearpay = () => {
   }
 }
 
-export default withRouter(AfterpayClearpay)
+export default AfterpayClearpay

--- a/custom-payment-flow/client/react-cra/src/Alipay.js
+++ b/custom-payment-flow/client/react-cra/src/Alipay.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -132,4 +132,4 @@ const Alipay = () => {
   }
 };
 
-export default withRouter(Alipay);
+export default Alipay;

--- a/custom-payment-flow/client/react-cra/src/App.js
+++ b/custom-payment-flow/client/react-cra/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {BrowserRouter as Switch, Route} from 'react-router-dom';
+import {BrowserRouter, Routes, Route} from 'react-router-dom';
 
 // Index page with list of payment methods.
 import List from './List';
@@ -32,71 +32,31 @@ function App(props) {
   return (
     <>
       <a href="/">home</a>
-      <Switch>
-        <Route exact path="/">
-          <List />
-        </Route>
-        <Route path="/alipay">
-          <Alipay />
-        </Route>
-        <Route path="/acss-debit">
-          <AcssDebit />
-        </Route>
-        <Route path="/apple-pay">
-          <ApplePay />
-        </Route>
-        <Route path="/afterpay-clearpay">
-          <AfterpayClearpay />
-        </Route>
-        <Route path="/bancontact">
-          <Bancontact />
-        </Route>
-        <Route path="/becs-debit">
-          <BecsDebit />
-        </Route>
-        <Route path="/boleto">
-          <Boleto />
-        </Route>
-        <Route path="/card">
-          <Card />
-        </Route>
-        <Route path="/eps">
-          <Eps />
-        </Route>
-        <Route path="/fpx">
-          <Fpx />
-        </Route>
-        <Route path="/giropay">
-          <Giropay />
-        </Route>
-        <Route path="/grabpay">
-          <GrabPay />
-        </Route>
-        <Route path="/google-pay">
-          <GooglePay />
-        </Route>
-        <Route path="/ideal">
-          <Ideal />
-        </Route>
-        <Route path="/klarna">
-          <Klarna />
-        </Route>
-        <Route path="/oxxo">
-          <Oxxo />
-        </Route>
-        <Route path="/p24">
-          <P24 />
-        </Route>
-        <Route path="/sepa-debit">
-          <SepaDebit />
-        </Route>
-        <Route path="/sofort">
-          <Sofort />
-        </Route>
-        <Route path="/wechat-pay">
-          <WeChatPay />
-        </Route>
-      </Switch>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<List />} />
+          <Route path="/alipay" element={<Alipay />} />
+          <Route path="/acss-debit" element={<AcssDebit />} />
+          <Route path="/apple-pay" element={<ApplePay />} />
+          <Route path="/afterpay-clearpay" element={<AfterpayClearpay />} />
+          <Route path="/bancontact" element={<Bancontact />} />
+          <Route path="/becs-debit" element={<BecsDebit />} />
+          <Route path="/boleto" element={<Boleto />} />
+          <Route path="/card" element={<Card />} />
+          <Route path="/eps" element={<Eps />} />
+          <Route path="/fpx" element={<Fpx />} />
+          <Route path="/giropay" element={<Giropay />} />
+          <Route path="/grabpay" element={<GrabPay />} />
+          <Route path="/google-pay" element={<GooglePay />} />
+          <Route path="/ideal" element={<Ideal />} />
+          <Route path="/klarna" element={<Klarna />} />
+          <Route path="/oxxo" element={<Oxxo />} />
+          <Route path="/p24" element={<P24 />} />
+          <Route path="/sepa-debit" element={<SepaDebit />} />
+          <Route path="/sofort" element={<Sofort />} />
+          <Route path="/wechat-pay" element={<WeChatPay />} />
+        </Routes>
+      </BrowserRouter>
     </>
   );
 }

--- a/custom-payment-flow/client/react-cra/src/ApplePay.js
+++ b/custom-payment-flow/client/react-cra/src/ApplePay.js
@@ -1,5 +1,4 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter} from 'react-router-dom';
 import {PaymentRequestButtonElement, useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -100,4 +99,4 @@ const ApplePay = () => {
   );
 };
 
-export default withRouter(ApplePay);
+export default ApplePay;

--- a/custom-payment-flow/client/react-cra/src/Bancontact.js
+++ b/custom-payment-flow/client/react-cra/src/Bancontact.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -133,4 +133,4 @@ const Bancontact = () => {
   }
 };
 
-export default withRouter(Bancontact);
+export default Bancontact;

--- a/custom-payment-flow/client/react-cra/src/BecsDebit.js
+++ b/custom-payment-flow/client/react-cra/src/BecsDebit.js
@@ -1,5 +1,4 @@
 import React, {useState} from 'react';
-import {withRouter} from 'react-router-dom';
 import {
   AuBankAccountElement,
   useStripe,
@@ -140,4 +139,4 @@ const BecsDebitForm = () => {
   );
 };
 
-export default withRouter(BecsDebitForm);
+export default BecsDebitForm;

--- a/custom-payment-flow/client/react-cra/src/Boleto.js
+++ b/custom-payment-flow/client/react-cra/src/Boleto.js
@@ -1,5 +1,4 @@
 import React, {useState} from 'react';
-import {withRouter} from 'react-router-dom';
 import {useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -60,7 +59,7 @@ const Boleto = () => {
               state,
               city,
               postal_code: postalCode,
-              line1, 
+              line1,
             },
             name,
             email,
@@ -181,4 +180,4 @@ const Boleto = () => {
   );
 };
 
-export default withRouter(Boleto);
+export default Boleto;

--- a/custom-payment-flow/client/react-cra/src/Card.js
+++ b/custom-payment-flow/client/react-cra/src/Card.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {withRouter} from 'react-router-dom';
 import {CardElement, useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -97,4 +96,4 @@ const CardForm = () => {
   );
 };
 
-export default withRouter(CardForm);
+export default CardForm;

--- a/custom-payment-flow/client/react-cra/src/Eps.js
+++ b/custom-payment-flow/client/react-cra/src/Eps.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {EpsBankElement, useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -130,4 +130,4 @@ const Eps = () => {
   }
 };
 
-export default withRouter(Eps);
+export default Eps;

--- a/custom-payment-flow/client/react-cra/src/Fpx.js
+++ b/custom-payment-flow/client/react-cra/src/Fpx.js
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {FpxBankElement, useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -121,4 +121,4 @@ const Fpx = () => {
   }
 };
 
-export default withRouter(Fpx);
+export default Fpx;

--- a/custom-payment-flow/client/react-cra/src/Giropay.js
+++ b/custom-payment-flow/client/react-cra/src/Giropay.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -133,4 +133,4 @@ const Giropay = () => {
   }
 };
 
-export default withRouter(Giropay);
+export default Giropay;

--- a/custom-payment-flow/client/react-cra/src/GooglePay.js
+++ b/custom-payment-flow/client/react-cra/src/GooglePay.js
@@ -1,5 +1,4 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter} from 'react-router-dom';
 import {PaymentRequestButtonElement, useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -97,4 +96,4 @@ const GooglePay = () => {
   );
 };
 
-export default withRouter(GooglePay);
+export default GooglePay;

--- a/custom-payment-flow/client/react-cra/src/GrabPay.js
+++ b/custom-payment-flow/client/react-cra/src/GrabPay.js
@@ -1,9 +1,9 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
-const GrabpayForm = () => {
+const GrabPayForm = () => {
   const stripe = useStripe();
   const elements = useElements();
   const [name, setName] = useState('Jenny Rosen');
@@ -91,7 +91,7 @@ const GrabpayForm = () => {
 
 // Component for displaying results after returning from
 // bancontact redirect flow.
-const GrabpayReturn = () => {
+const GrabPayReturn = () => {
   const stripe = useStripe();
   const [messages, addMessage] = useMessages();
 
@@ -124,13 +124,13 @@ const GrabpayReturn = () => {
   );
 };
 
-const Grabpay = () => {
+const GrabPay = () => {
   const query = new URLSearchParams(useLocation().search);
   if (query.get('return')) {
-    return <GrabpayReturn />;
+    return <GrabPayReturn />;
   } else {
-    return <GrabpayForm />;
+    return <GrabPayForm />;
   }
 };
 
-export default withRouter(Grabpay);
+export default GrabPay;

--- a/custom-payment-flow/client/react-cra/src/Ideal.js
+++ b/custom-payment-flow/client/react-cra/src/Ideal.js
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {
   IdealBankElement,
   useStripe,
@@ -129,4 +129,4 @@ const Ideal = () => {
   }
 };
 
-export default withRouter(Ideal);
+export default Ideal;

--- a/custom-payment-flow/client/react-cra/src/Klarna.js
+++ b/custom-payment-flow/client/react-cra/src/Klarna.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {KlarnaElement, useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -163,4 +163,4 @@ const Klarna = () => {
   }
 }
 
-export default withRouter(KlarnaForm);
+export default KlarnaForm;

--- a/custom-payment-flow/client/react-cra/src/List.js
+++ b/custom-payment-flow/client/react-cra/src/List.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import {withRouter} from 'react-router-dom';
-
 // List of payment method types with links to each implementation.
 const List = () => {
   const CARDS = 'Cards';
@@ -234,4 +232,4 @@ const List = () => {
   );
 };
 
-export default withRouter(List);
+export default List;

--- a/custom-payment-flow/client/react-cra/src/Oxxo.js
+++ b/custom-payment-flow/client/react-cra/src/Oxxo.js
@@ -1,5 +1,4 @@
 import React, {useState} from 'react';
-import {withRouter} from 'react-router-dom';
 import {useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -118,4 +117,4 @@ const OxxoForm = () => {
   );
 };
 
-export default withRouter(OxxoForm);
+export default OxxoForm;

--- a/custom-payment-flow/client/react-cra/src/P24.js
+++ b/custom-payment-flow/client/react-cra/src/P24.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {P24BankElement, useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -152,4 +152,4 @@ const P24 = () => {
   }
 };
 
-export default withRouter(P24);
+export default P24;

--- a/custom-payment-flow/client/react-cra/src/SepaDebit.js
+++ b/custom-payment-flow/client/react-cra/src/SepaDebit.js
@@ -1,5 +1,4 @@
 import React, {useState} from 'react';
-import {withRouter} from 'react-router-dom';
 import {IbanElement, useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -143,4 +142,4 @@ const SepaDebitForm = () => {
   );
 };
 
-export default withRouter(SepaDebitForm);
+export default SepaDebitForm;

--- a/custom-payment-flow/client/react-cra/src/Sofort.js
+++ b/custom-payment-flow/client/react-cra/src/Sofort.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 import {useStripe, useElements} from '@stripe/react-stripe-js';
 import StatusMessages, {useMessages} from './StatusMessages';
 
@@ -147,4 +147,4 @@ const Sofort = () => {
   }
 };
 
-export default withRouter(Sofort);
+export default Sofort;

--- a/custom-payment-flow/client/react-cra/src/WeChatPay.js
+++ b/custom-payment-flow/client/react-cra/src/WeChatPay.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {withRouter} from 'react-router-dom';
 import StatusMessages, {useMessages} from './StatusMessages';
 import {useStripe} from '@stripe/react-stripe-js';
 
@@ -68,4 +67,4 @@ const WeChatPay = () => {
   )
 }
 
-export default withRouter(WeChatPay);
+export default WeChatPay;

--- a/prebuilt-checkout-page/client/react-cra/src/index.js
+++ b/prebuilt-checkout-page/client/react-cra/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {BrowserRouter as Router, Switch, Route} from 'react-router-dom';
+import {BrowserRouter, Routes, Route} from 'react-router-dom';
 
 import Checkout from './components/Checkout';
 import Success from './components/Success';
@@ -11,19 +11,13 @@ import './css/global.css';
 
 function App() {
   return (
-    <Router>
-      <Switch>
-        <Route path="/success.html">
-          <Success />
-        </Route>
-        <Route path="/canceled.html">
-          <Canceled />
-        </Route>
-        <Route path="/">
-          <Checkout />
-        </Route>
-      </Switch>
-    </Router>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/success.html" element={<Success />} />
+        <Route path="/canceled.html" element={<Canceled />} />
+        <Route path="/" element={<Checkout />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 


### PR DESCRIPTION
Hello. I have migrated react-router to v6 for the react-cra apps and this should make CI pass.
https://github.com/remix-run/react-router/blob/main/docs/upgrading/v5.md

The latest CI result on my fork: https://github.com/hibariya/accept-a-payment/actions/runs/1749445858
