### PR TITLE
E2E tests for payment-element

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
             tests: custom_payment_flow_e2e_spec.rb
           - sample: prebuilt-checkout-page
             tests: prebuilt_checkout_page_e2e_spec.rb
+          - sample: payment-element
+            tests: payment_element_e2e_spec.rb
     env:
       SERVER_URL: ${{ matrix.implementation.server_url }}
     steps:

--- a/payment-element/client/html/index.html
+++ b/payment-element/client/html/index.html
@@ -24,7 +24,7 @@
         <div id="payment-element">
           <!-- Elements will create form elements here -->
         </div>
-        <button id="submit">Submit</button>
+        <button id="submit">Pay now</button>
         <div id="error-message">
           <!-- Display error message to your customers here -->
         </div>

--- a/payment-element/client/react-cra/package-lock.json
+++ b/payment-element/client/react-cra/package-lock.json
@@ -5614,6 +5614,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
+      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -9162,6 +9170,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
+      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
+      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.2.1"
+      }
     },
     "react-scripts": {
       "version": "5.0.0",

--- a/payment-element/client/react-cra/package.json
+++ b/payment-element/client/react-cra/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
     "web-vitals": "^2.1.4"
   },

--- a/payment-element/client/react-cra/src/App.js
+++ b/payment-element/client/react-cra/src/App.js
@@ -1,40 +1,30 @@
-import logo from './logo.svg';
 import './App.css';
+import Payment from './Payment'
+import Completion from './Completion'
 
 import {useEffect, useState} from 'react';
+import {BrowserRouter, Routes, Route} from 'react-router-dom';
 
 import {loadStripe} from '@stripe/stripe-js';
-import {Elements} from '@stripe/react-stripe-js';
-import CheckoutForm from './CheckoutForm'
-
-let stripePromise;
-(async () => {
-  const {publishableKey} = await fetch("/config").then(r => r.json());
-  stripePromise = loadStripe(publishableKey)
-})()
 
 function App() {
-  const [clientSecret, setClientSecret] = useState('');
+  const [ stripePromise, setStripePromise ] = useState(null);
 
   useEffect(() => {
-    // Create PaymentIntent as soon as the page loads
-    fetch("/create-payment-intent")
-      .then((res) => res.json())
-      .then(({clientSecret}) => setClientSecret(clientSecret));
-  }, [])
-
-  const options = {
-    clientSecret,
-  }
+    fetch("/config").then(async (r) => {
+      const { publishableKey } = await r.json();
+      setStripePromise(loadStripe(publishableKey));
+    });
+  }, []);
 
   return (
     <main>
-      <h1>Payment</h1>
-      {clientSecret && (
-        <Elements stripe={stripePromise} options={options}>
-          <CheckoutForm />
-        </Elements>
-      )}
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Payment stripePromise={stripePromise} />} />
+          <Route path="/completion" element={<Completion stripePromise={stripePromise} />} />
+        </Routes>
+      </BrowserRouter>
     </main>
   );
 }

--- a/payment-element/client/react-cra/src/CheckoutForm.js
+++ b/payment-element/client/react-cra/src/CheckoutForm.js
@@ -25,7 +25,7 @@ export default function CheckoutForm() {
       elements,
       confirmParams: {
         // Make sure to change this to your payment completion page
-        return_url: "http://localhost:3000",
+        return_url: `${window.location.origin}/completion`,
       },
     });
 

--- a/payment-element/client/react-cra/src/Completion.js
+++ b/payment-element/client/react-cra/src/Completion.js
@@ -1,0 +1,30 @@
+import {useEffect, useState} from 'react';
+
+function Completion(props) {
+  const [ messageBody, setMessageBody ] = useState('');
+  const { stripePromise } = props;
+
+  useEffect(() => {
+    if (!stripePromise) return;
+
+    stripePromise.then(async (stripe) => {
+      const url = new URL(window.location);
+      const clientSecret = url.searchParams.get('payment_intent_client_secret');
+      const { error, paymentIntent } = await stripe.retrievePaymentIntent(clientSecret);
+
+      setMessageBody(error ? `> ${error.message}` : (
+        <>&gt; Payment {paymentIntent.status}: <a href={`https://dashboard.stripe.com/test/payments/${paymentIntent.id}`} target="_blank" rel="noreferrer">{paymentIntent.id}</a></>
+      ));
+    });
+  }, [stripePromise]);
+
+  return (
+    <>
+      <h1>Thank you!</h1>
+      <a href="/">home</a>
+      <div id="messages" role="alert" style={messageBody ? {display: 'block'} : {}}>{messageBody}</div>
+    </>
+  );
+}
+
+export default Completion;

--- a/payment-element/client/react-cra/src/Payment.js
+++ b/payment-element/client/react-cra/src/Payment.js
@@ -1,0 +1,30 @@
+import {useEffect, useState} from 'react';
+
+import {Elements} from '@stripe/react-stripe-js';
+import CheckoutForm from './CheckoutForm'
+
+function Payment(props) {
+  const { stripePromise } = props;
+  const [ clientSecret, setClientSecret ] = useState('');
+
+  useEffect(() => {
+    // Create PaymentIntent as soon as the page loads
+    fetch("/create-payment-intent")
+      .then((res) => res.json())
+      .then(({clientSecret}) => setClientSecret(clientSecret));
+  }, []);
+
+
+  return (
+    <>
+      <h1>Payment</h1>
+      {clientSecret && stripePromise && (
+        <Elements stripe={stripePromise} options={{ clientSecret, }}>
+          <CheckoutForm />
+        </Elements>
+      )}
+    </>
+  );
+}
+
+export default Payment;

--- a/payment-element/client/react-cra/yarn.lock
+++ b/payment-element/client/react-cra/yarn.lock
@@ -1728,6 +1728,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.6":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.0.tgz#b8d142fc0f7664fb3d9b5833fd40dcbab89276c0"
+  integrity sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -5319,6 +5326,13 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+history@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.2.0.tgz#7cdd31cf9bac3c5d31f09c231c9928fad0007b7c"
+  integrity sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hoopy@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
@@ -8017,6 +8031,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.2.1.tgz#32ec81829152fbb8a7b045bf593a22eadf019bec"
+  integrity sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.2.1"
+
+react-router@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.1.tgz#be2a97a6006ce1d9123c28934e604faef51448a3"
+  integrity sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@5.0.0:
   version "5.0.0"

--- a/spec/payment_element_e2e_spec.rb
+++ b/spec/payment_element_e2e_spec.rb
@@ -1,0 +1,23 @@
+require 'capybara_support'
+
+RSpec.describe 'Payment elements', type: :system do
+  before do
+    visit server_url('/')
+  end
+
+  example 'happy path' do
+    within_frame first('form iframe') do
+      fill_in 'number', with: '4242424242424242'
+      fill_in 'expiry', with: '12 / 33'
+      fill_in 'cvc', with: '123'
+      select 'United States', from: 'country'
+      fill_in 'postalCode', with: '10000'
+    end
+
+    click_on 'Pay now'
+
+    expect(page).to have_no_content('Pay now')
+    expect(page).to have_content('Thank you!')
+    expect(page).to have_content('Payment succeeded')
+  end
+end


### PR DESCRIPTION
I added a minimum e2e test for the payment-element samples. I also changed the react-cra sample to have a completion page (/completion) as well as the other sample because I think it seems good for both developer experience and test maintenance. 

The page added: 
![image](https://user-images.githubusercontent.com/43346/153199782-93e31f78-d832-4db9-aa28-dbc37c8f1c3b.png)

The latest CI result on my fork: https://github.com/hibariya/accept-a-payment/actions/runs/1817945965