### PR TITLE
Fix failing CI due to version mismatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
             server_image: golang:1.16
           - server_type: go
             server_image: golang:1.15
-          - server_type: dotnet
-            server_image: mcr.microsoft.com/dotnet/sdk:5.0
-          - server_type: dotnet
-            server_image: mcr.microsoft.com/dotnet/sdk:3.1
         target:
           - sample: custom-payment-flow
             tests: custom_payment_flow_server_spec.rb
@@ -62,6 +58,24 @@ jobs:
             target:
               sample: custom-payment-flow
               tests: custom_payment_flow_server_spec.rb
+          - runtime:
+              server_type: dotnet
+              server_image: mcr.microsoft.com/dotnet/sdk:6.0
+            target:
+              sample: custom-payment-flow
+              tests: custom_payment_flow_server_spec.rb
+          - runtime:
+              server_type: dotnet
+              server_image: mcr.microsoft.com/dotnet/sdk:5.0
+            target:
+              sample: prebuilt-checkout-page
+              tests: prebuilt_checkout_page_spec.rb
+          - runtime:
+              server_type: dotnet
+              server_image: mcr.microsoft.com/dotnet/sdk:3.1
+            target:
+              sample: prebuilt-checkout-page
+              tests: prebuilt_checkout_page_spec.rb
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
It looks the .Net implementation of custom-payment-flow sample now supports only 6.0 but the CI is still trying to run with 3.1 and 5.0. I've modified the CI settings so that it only runs with 6.0.
