### PR TITLE
Fix failing e2e tests

### DIFF
--- a/spec/payment_element_e2e_spec.rb
+++ b/spec/payment_element_e2e_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Payment elements', type: :system do
   end
 
   example 'happy path' do
-    within_frame first('form iframe') do
+    within_frame first('form iframe[title*="payment input"][src*="elements-inner-payment"]') do
       fill_in 'number', with: '4242424242424242'
       fill_in 'expiry', with: '12 / 33'
       fill_in 'cvc', with: '123'


### PR DESCRIPTION
Hi. The test was failing because it was looking for a different iframe. I changed to specify the src and title.

I had to specify the src as well as the title since an iframe that has the same title appears first with a different src and then disappears. The iframe we are looking for here appears after that.