### PR TITLE
chore: ignore E2E test executors and Yarn files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,12 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 
 spec/examples.txt
+
+# Yarn files (we recommended to use npm)
+yarn*
+
+# E2E test
+#
+# We can run the E2E testing script, but sometime it remain several files.
+docker-compose*
+sample-ci/


### PR DESCRIPTION
Just update the `.gitignore` file.

Added items:
- yarn*: sometime I use Yarn instead of npm, but I don't want to commit these files.
- docker-compose* & sample-ci: If we run the E2E test in our local env, we get these files.