### PR TITLE
Fix failing tests for prebuilt-checkout-page .Net sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
             server_image: golang:1.16
           - server_type: go
             server_image: golang:1.15
+          - server_type: dotnet
+            server_image: mcr.microsoft.com/dotnet/sdk:6.0
         target:
           - sample: custom-payment-flow
             tests: custom_payment_flow_server_spec.rb
@@ -58,24 +60,6 @@ jobs:
             target:
               sample: custom-payment-flow
               tests: custom_payment_flow_server_spec.rb
-          - runtime:
-              server_type: dotnet
-              server_image: mcr.microsoft.com/dotnet/sdk:6.0
-            target:
-              sample: custom-payment-flow
-              tests: custom_payment_flow_server_spec.rb
-          - runtime:
-              server_type: dotnet
-              server_image: mcr.microsoft.com/dotnet/sdk:5.0
-            target:
-              sample: prebuilt-checkout-page
-              tests: prebuilt_checkout_page_spec.rb
-          - runtime:
-              server_type: dotnet
-              server_image: mcr.microsoft.com/dotnet/sdk:3.1
-            target:
-              sample: prebuilt-checkout-page
-              tests: prebuilt_checkout_page_spec.rb
     steps:
       - uses: actions/checkout@v2
 

--- a/prebuilt-checkout-page/server/dotnet/Program.cs
+++ b/prebuilt-checkout-page/server/dotnet/Program.cs
@@ -49,6 +49,8 @@ app.UseStaticFiles(new StaticFileOptions()
     RequestPath = new PathString("")
 });
 
+app.MapGet("/", () => Results.Redirect("index.html"));
+
 app.MapGet("checkout-session", async (string sessionId) =>
 {
     var service = new SessionService();
@@ -56,7 +58,7 @@ app.MapGet("checkout-session", async (string sessionId) =>
     return Results.Ok(session);
 });
 
-app.MapPost("create-checkout-session", async (IOptions<StripeOptions> options) =>
+app.MapPost("create-checkout-session", async (IOptions<StripeOptions> options, HttpContext context) =>
 {
     // Create new Checkout Session for the order
     // Other optional params include:
@@ -85,7 +87,8 @@ app.MapPost("create-checkout-session", async (IOptions<StripeOptions> options) =
 
     var service = new SessionService();
     var session = await service.CreateAsync(sessionOptions);
-    return Results.Redirect(session.Url);
+    context.Response.Headers.Add("Location", session.Url);
+    return Results.StatusCode(303);
 });
 
 app.MapPost("webhook", async (HttpRequest req, IOptions<StripeOptions> options) =>


### PR DESCRIPTION
Since now both `custom-payment-flow` and `prebuilt-checkout-page` only support 6.0, we no longer have to treat them as special cases and I removed them from the `include:` section.

Also, applied a couple of changes:

* Added the route to `/` the same as [`custom-payment-flow/server/dotnet/Program.cs`](https://github.com/stripe-samples/accept-a-payment/blob/efbc525776ebf77e11efca1bfd5bf50dcd255948/custom-payment-flow/server/dotnet/Program.cs#L40).
* Changed the status code of `POST /create-checkout-session`. The existing RSpec test expects it returns 303.

Related: #623