### PR TITLE
Make CI run payment-element tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
             tests: custom_payment_flow_server_spec.rb
           - sample: prebuilt-checkout-page
             tests: prebuilt_checkout_page_spec.rb
+          - sample: payment-element
+            tests: payment_element_server_spec.rb
         include:
           - runtime:
               server_type: node-typescript

--- a/payment-element/server/dotnet/Program.cs
+++ b/payment-element/server/dotnet/Program.cs
@@ -39,9 +39,10 @@ app.UseStaticFiles(new StaticFileOptions()
     RequestPath = new PathString("")
 });
 
+app.MapGet("/", () => Results.Redirect("index.html"));
 app.MapGet("/config", (IOptions<StripeOptions> options) => new { options.Value.PublishableKey });
 
-app.MapPost("/create-payment-intent", async () =>
+app.MapGet("/create-payment-intent", async () =>
 {
     try
     {


### PR DESCRIPTION
Hi. I changed the CI settings to run payment-element tests.
Also, I fixed the .Net implementation to pass the tests:

- Added a missing route (`/`).
- Changed to use GET instead of POST for `/create-payment-intent` as with other implementations.