### PR TITLE
E2e tests for prebuilt-checkout-page/client/vue-cva

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,10 @@ jobs:
       matrix:
         implementation:
           - client_type: html
-            server_url: http://web:4242
+            domain: http://web:4242
             profile: e2e
           - client_type: react-cra
-            server_url: http://frontend:3000
+            domain: http://frontend:3000
             profile: frontend
         target:
           - sample: custom-payment-flow
@@ -119,8 +119,14 @@ jobs:
             tests: prebuilt_checkout_page_e2e_spec.rb
           - sample: payment-element
             tests: payment_element_e2e_spec.rb
-    env:
-      SERVER_URL: ${{ matrix.implementation.server_url }}
+        include:
+          - implementation:
+              client_type: vue-cva
+              domain: http://frontend:3000
+              profile: frontend
+            target:
+              sample: prebuilt-checkout-page
+              tests: prebuilt_checkout_page_e2e_spec.rb
     steps:
       - uses: actions/checkout@v2
 
@@ -128,6 +134,7 @@ jobs:
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
+          ref: 'vue-cva'
 
       - name: Setup dependencies
         run: |
@@ -145,13 +152,13 @@ jobs:
           install_docker_compose_settings
           export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
           cat <<EOF >> .env
-          DOMAIN=${{ matrix.implementation.server_url }}
+          DOMAIN=${{ matrix.implementation.domain }}
           PRICE=${{ secrets.TEST_PRICE }}
           PAYMENT_METHOD_TYPES="card"
           EOF
 
           configure_docker_compose_for_integration "${{ matrix.target.sample }}" node ../../client/${{ matrix.implementation.client_type }} node:14.17
-          docker-compose --profile="${{ matrix.implementation.profile }}" up -d && wait_web_server
+          docker-compose --profile="${{ matrix.implementation.profile }}" up -d && wait_web_server && wait_web_server "${{ matrix.implementation.domain }}"
           command="docker-compose exec -T runner bundle exec rspec spec/${{ matrix.target.tests }}"
           $command \
             || $command --only-failures \
@@ -163,7 +170,7 @@ jobs:
           cat .env
           cat docker-compose.yml
           docker-compose ps -a
-          docker-compose --profile="${{ matrix.implementation.profile }}" logs web
+          docker-compose --profile="${{ matrix.implementation.profile }}" logs web frontend
 
           docker cp $(docker-compose ps -qa runner | head -1):/work/tmp .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
-          ref: 'vue-cva'
 
       - name: Setup dependencies
         run: |

--- a/prebuilt-checkout-page/client/vue-cva/vite.config.js
+++ b/prebuilt-checkout-page/client/vue-cva/vite.config.js
@@ -4,11 +4,12 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue(), pluginRewriteAll()], 
+  plugins: [vue(), pluginRewriteAll()],
   server: {
+    host: "0.0.0.0",
     proxy: {
       "/api": {
-        target: "http://localhost:4242",
+        target: process.env.SERVER_URL || 'http://localhost:4242',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       }

--- a/spec/capybara_support.rb
+++ b/spec/capybara_support.rb
@@ -20,10 +20,10 @@ Capybara.enable_aria_label = true
 Capybara.save_path = 'tmp/capybara'
 
 module CapybaraHelpers
-  SERVER_URL = ENV.fetch('SERVER_URL', 'http://web:4242')
+  APP_URL = ENV.fetch('DOMAIN', 'http://frontend:3000')
 
-  def server_url(path)
-    url = URI(SERVER_URL)
+  def app_url(path)
+    url = URI(APP_URL)
     url.path = path
     url
   end

--- a/spec/custom_payment_flow_e2e_spec.rb
+++ b/spec/custom_payment_flow_e2e_spec.rb
@@ -2,7 +2,7 @@ require 'capybara_support'
 
 RSpec.describe 'Custom payment flow', type: :system do
   before do
-    visit server_url('/')
+    visit app_url('/')
   end
 
   example 'Card: happy path' do

--- a/spec/payment_element_e2e_spec.rb
+++ b/spec/payment_element_e2e_spec.rb
@@ -2,7 +2,7 @@ require 'capybara_support'
 
 RSpec.describe 'Payment elements', type: :system do
   before do
-    visit server_url('/')
+    visit app_url('/')
   end
 
   example 'happy path' do

--- a/spec/prebuilt_checkout_page_e2e_spec.rb
+++ b/spec/prebuilt_checkout_page_e2e_spec.rb
@@ -2,7 +2,7 @@ require 'capybara_support'
 
 RSpec.describe 'Custom payment flow', type: :system do
   before do
-    visit server_url('/')
+    visit app_url('/')
   end
 
   example 'happy path' do
@@ -23,7 +23,7 @@ RSpec.describe 'Custom payment flow', type: :system do
   end
 
   example 'Cancel a payment' do
-    visit server_url('/')
+    visit app_url('/')
 
     click_on 'Buy'
     click_on 'Previous page'

--- a/spec/prebuilt_checkout_page_spec.rb
+++ b/spec/prebuilt_checkout_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "prebuilt-checkout-page integration" do
   describe '/create-checkout-session' do
     it 'creates a checkout session' do
       response = RestClient.post(
-        "#{SERVER_URL}/create-checkout-session",
+        server_url("/create-checkout-session"),
         {quantity: 7},
         {max_redirects: 0}
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,23 +113,25 @@ Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 Stripe.max_network_retries = 2
 Stripe.api_version = "2020-08-27"
 
-def server_url
-  SERVER_URL
+def server_url(path)
+  url = URI(SERVER_URL)
+  url.path = path
+  url.to_s
 end
 
 def get(path, *args, **kwargs)
-  RestClient.get("#{SERVER_URL}#{path}", *args, **kwargs)
+  RestClient.get(server_url(path), *args, **kwargs)
 end
 
 def get_json(path, *args, **kwargs)
-  response = RestClient.get("#{SERVER_URL}#{path}", *args, **kwargs)
+  response = RestClient.get(server_url(path), *args, **kwargs)
   JSON.parse(response.body)
 end
 
 def post_json(path, payload, **kwargs)
   defaults = {content_type: :json}
   response = RestClient.post(
-    "#{SERVER_URL}#{path}",
+    server_url(path),
     payload.to_json,
     defaults.merge(**kwargs)
   )


### PR DESCRIPTION
Hi, I made CI run e2e tests for  prebuilt-checkout-page/client/vue-cva. 

I replaced a few `SERVER_URL` with `DOMAIN` because they should point to the URL that provides the UI in the first place (I think I mixed them up when I added the e2e tests). `DOMAIN` always points to the UI but `SERVER_URL` always points to the server-side API with port 4242. 

I also modified CI to wait for frontend apps to be ready because sometimes frontend apps take a certain time. To that end, now `wait_web_server` takes an arbitrary URL.