### PR TITLE
Disable unstable e2e tests by default

### DIFF
--- a/.github/workflows/android_e2e.yml
+++ b/.github/workflows/android_e2e.yml
@@ -1,0 +1,41 @@
+name: Android e2e tests
+on: workflow_dispatch
+
+env:
+  STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+  STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e_android:
+    runs-on: macos-11
+    env:
+      STRIPE_API_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+      PRICE: ${{ secrets.TEST_PRICE }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup dependencies
+        run: |
+          curl -o- -L https://github.com/stripe/stripe-cli/releases/download/v1.7.0/stripe_1.7.0_mac-os_x86_64.tar.gz | sudo tar fxz - -C /usr/local/bin
+
+      - name: Run tests (1st attempt)
+        timeout-minutes: 10
+        continue-on-error: true
+        id: attempt1
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          script: .github/workflows/android_e2e.sh
+
+      - name: Run tests (2nd attempt)
+        timeout-minutes: 10
+        id: attempt2
+        if: steps.attempt1.outcome=='failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          script: .github/workflows/android_e2e.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,35 +181,14 @@ jobs:
           path: |
             tmp/capybara
 
-  e2e_android:
-    runs-on: macos-11
-    env:
-      STRIPE_API_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
-      PRICE: ${{ secrets.TEST_PRICE }}
+  android_build:
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup dependencies
+      - name: Build
         run: |
-          curl -o- -L https://github.com/stripe/stripe-cli/releases/download/v1.7.0/stripe_1.7.0_mac-os_x86_64.tar.gz | sudo tar fxz - -C /usr/local/bin
-
-      - name: Run tests (1st attempt)
-        timeout-minutes: 10
-        continue-on-error: true
-        id: attempt1
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 29
-          script: .github/workflows/android_e2e.sh
-
-      - name: Run tests (2nd attempt)
-        timeout-minutes: 10
-        id: attempt2
-        if: steps.attempt1.outcome=='failure'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 29
-          script: .github/workflows/android_e2e.sh
+          cd custom-payment-flow/client/android-kotlin
+          ./gradlew build
 
   ios_build:
     runs-on: macos-11
@@ -226,41 +205,3 @@ jobs:
                      CODE_SIGNING_REQUIRED="NO" \
                      CODE_SIGN_ENTITLEMENTS="" \
                      CODE_SIGNING_ALLOWED="NO"
-
-  e2e_react_native_android:
-    runs-on: macos-11
-    env:
-      STRIPE_API_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
-      PRICE: ${{ secrets.TEST_PRICE }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup dependencies
-        run: |
-          curl -o- -L https://github.com/stripe/stripe-cli/releases/download/v1.7.0/stripe_1.7.0_mac-os_x86_64.tar.gz | sudo tar fxz - -C /usr/local/bin
-
-      - name: Run tests (1st attempt)
-        timeout-minutes: 15
-        continue-on-error: true
-        id: attempt1
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 29
-          script: .github/workflows/react_native_android_e2e.sh
-
-      - name: Run tests (2nd attempt)
-        timeout-minutes: 15
-        id: attempt2
-        if: steps.attempt1.outcome=='failure'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 29
-          script: .github/workflows/react_native_android_e2e.sh
-
-      - name: Upload screenshots
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: react-native-android-screenshots
-          path: |
-            custom-payment-flow/client/react-native-expo/tmp/screenshots

--- a/.github/workflows/react_native_android_e2e.yml
+++ b/.github/workflows/react_native_android_e2e.yml
@@ -1,0 +1,49 @@
+name: React Native Android e2e tests
+on: workflow_dispatch
+
+env:
+  STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+  STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e_react_native_android:
+    runs-on: macos-11
+    env:
+      STRIPE_API_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+      PRICE: ${{ secrets.TEST_PRICE }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup dependencies
+        run: |
+          curl -o- -L https://github.com/stripe/stripe-cli/releases/download/v1.7.0/stripe_1.7.0_mac-os_x86_64.tar.gz | sudo tar fxz - -C /usr/local/bin
+
+      - name: Run tests (1st attempt)
+        timeout-minutes: 15
+        continue-on-error: true
+        id: attempt1
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          script: .github/workflows/react_native_android_e2e.sh
+
+      - name: Run tests (2nd attempt)
+        timeout-minutes: 15
+        id: attempt2
+        if: steps.attempt1.outcome=='failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          script: .github/workflows/react_native_android_e2e.sh
+
+      - name: Upload screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: react-native-android-screenshots
+          path: |
+            custom-payment-flow/client/react-native-expo/tmp/screenshots


### PR DESCRIPTION
Hi. I made Android e2e tests disabled by default because they have been unstable.

The motivation for this change is to prevent missing other errors. To that end, I extracted these jobs to other workflows. The extracted workflows do not run by push events but we can run them by triggering them manually (haven't tried yet; we can confirm it after merging this to the main branch).

Right now I do not have ideas to fix this instability. We can bring them back to the original workflow when we find a way to make them stable.

See also: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow