### PR TITLE
Use Python 3.7 and 3.10 for testing on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           - server_type: node
             server_image: node:12.22
           - server_type: python
-            server_image: python:3.9
+            server_image: python:3.10
           - server_type: python
-            server_image: python:3.6
+            server_image: python:3.7
           - server_type: java
             server_image: maven:3.8-openjdk-16
           - server_type: java


### PR DESCRIPTION
Hiya. Since Python 3.6 has already reached its EOL and the latest one is now 3.10, I changed `ci.yml` to use them. I think it will fix the related errors ([like this](https://github.com/stripe-samples/accept-a-payment/runs/5817275263?check_suite_focus=true#step:6:88)) on the latest CI run.