### PR TITLE
OXXO payments seem working on CI now

### DIFF
--- a/spec/custom_payment_flow_e2e_spec.rb
+++ b/spec/custom_payment_flow_e2e_spec.rb
@@ -188,8 +188,12 @@ RSpec.describe 'Custom payment flow', type: :system do
     click_on 'OXXO'
 
     click_on 'Pay'
-    expect(page).to have_no_content('succeeded')
-    expect(page).to have_content('The payment method type provided: oxxo is invalid') # This payment method is available to Stripe accounts in MX and your Stripe account is in US.
+
+    within_frame find('iframe[name*=__privateStripeFrame]') do
+      within_frame find('iframe[title*="OXXO Voucher"]') do
+        expect(page).to have_content('Instructions to pay your OXXO')
+      end
+    end
   end
 
   example 'Alipay' do


### PR DESCRIPTION
Originally the OXXO sample didn't work with the account on CI and now it seems working. This PR changes the test to expect to display the voucher dialog.

This screenshot was taken when the original test failed:
![screenshot_2022-04-14-14-36-34 615](https://user-images.githubusercontent.com/43346/163732835-b506eaed-e2bf-48a2-8245-34d73d1aef5c.png)

