### PR TITLE
Remove node-typescript mention from README

### DIFF
--- a/prebuilt-checkout-page/README.md
+++ b/prebuilt-checkout-page/README.md
@@ -38,7 +38,6 @@ Pick a server:
 - [go](./server/go)
 - [java](./server/java)
 - [node](./server/node)
-- [node-typescript](./server/node-typescript)
 - [php](./server/php)
 - [python](./server/python)
 - [ruby](./server/ruby)


### PR DESCRIPTION
The README for the `prebuilt-checkout-page` projects link to a node-typescript backend but we don't actually have one, so I propose removing the link.