### PR TITLE
Fix failing tests: custom-payment-flow/server/node-typescript with node:latest

### DIFF
--- a/custom-payment-flow/server/node-typescript/package.json
+++ b/custom-payment-flow/server/node-typescript/package.json
@@ -4,8 +4,8 @@
   "description": "Stripe payment sample.",
   "main": "dist/server.js",
   "scripts": {
-    "build": "node_modules/typescript/bin/tsc",
-    "prestart": "npm run build",
+    "build": "tsc",
+    "prestart": "tsc",
     "start": "node .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Calling `npm run build` from `prestart` caused exit code 243 for some reason (I couldn't figure out why).
So I made it call the `tsc` command directly.

An example of these failed CI runs: https://github.com/stripe-samples/accept-a-payment/runs/6414802422?check_suite_focus=true#step:6:86