### PR TITLE
Fix label in Klarna example

### DIFF
--- a/custom-payment-flow/client/html/klarna.html
+++ b/custom-payment-flow/client/html/klarna.html
@@ -35,7 +35,7 @@
 
       <form id="payment-form">
         <label for="email">
-          Name
+          Email
         </label>
         <input type="email" id="email" placeholder="jenny.rosen@example.com" value="user-us@example.com" required />
 


### PR DESCRIPTION
Just a small typo fix. Field is `type="email"`, but label said "Name"