### PR TITLE
Run CI on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI for stripe-samples/accept-a-payment
 on:
-  push:
-    branches:
-      - '**'
-      - '!dependabot/**'
+  - push
 
 env:
   STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}


### PR DESCRIPTION
I forgot to enable CIs on branches created by Dependabot on #1081 :pray:
By merging this, only related tests to the changes will run on each topic branch.