### PR TITLE
Update Stripe API version

### DIFF
--- a/custom-payment-flow/server/node-typescript/src/server.ts
+++ b/custom-payment-flow/server/node-typescript/src/server.ts
@@ -9,7 +9,7 @@ import express from "express";
 
 import Stripe from "stripe";
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2020-08-27",
+  apiVersion: "2022-08-01",
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/accept-a-payment",
     url: "https://github.com/stripe-samples",

--- a/spec/custom_payment_flow_e2e_spec.rb
+++ b/spec/custom_payment_flow_e2e_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Custom payment flow', type: :system do
 
     click_on 'Pay'
     expect(page).to have_no_content('succeeded')
-    expect(page).to have_content('we currently require your account to have a bank account in one of the following currencies: aud')
+    expect(page).to have_content(/This payment method is available to Stripe accounts in AU/i)
   end
 
   example 'SEPA Direct Debit: happy path' do


### PR DESCRIPTION
I updated the `apiVersion` for node-typescript samples because the library's types only reflect the latest API version (the latest version when the library is released).
