### PR TITLE
The button label has been changed

### DIFF
--- a/spec/custom_payment_flow_e2e_spec.rb
+++ b/spec/custom_payment_flow_e2e_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Custom payment flow', type: :system do
       within_frame first('iframe') do
         click_on 'Agree'
         find('span', text: 'Simulate successful verification').click
-        click_on 'Pay CA$59.99'
+        click_on 'Agree'
       end
     end
 


### PR DESCRIPTION
Happy new year :sunrise: 
[A couple of CI jobs](https://github.com/stripe-samples/accept-a-payment/actions/runs/3702478034) were failing since a button in the ACSS debit payment has been changed. This should fix that.