### PR TITLE
File.exists? is deprecated and removed from Ruby 3.2

### DIFF
--- a/custom-payment-flow/server/ruby/config_helper.rb
+++ b/custom-payment-flow/server/ruby/config_helper.rb
@@ -95,7 +95,7 @@ class ConfigHelper
       DOC
     end
 
-    if !File.exists?(File.join(static_dir_path, 'index.html'))
+    if !File.exist?(File.join(static_dir_path, 'index.html'))
       if static_dir == ''
         puts <<~DOC
           No value set for STATIC_DIR. If this sample was installed with the
@@ -214,7 +214,7 @@ class ConfigHelper
 
   def dotenv_exists?
     puts "Checking that `.env` exists..."
-    return if File.exists?("./.env")
+    return if File.exist?("./.env")
 
     env_file_path = File.join(File.dirname(__FILE__), '.env')
     if !ENV['STRIPE_SECRET_KEY'] && !File.exist?("./.env")

--- a/payment-element/server/ruby/config_helper.rb
+++ b/payment-element/server/ruby/config_helper.rb
@@ -95,7 +95,7 @@ class ConfigHelper
       DOC
     end
 
-    if !File.exists?(File.join(static_dir_path, 'index.html'))
+    if !File.exist?(File.join(static_dir_path, 'index.html'))
       if static_dir == ''
         puts <<~DOC
           No value set for STATIC_DIR. If this sample was installed with the
@@ -214,7 +214,7 @@ class ConfigHelper
 
   def dotenv_exists?
     puts "Checking that `.env` exists..."
-    return if File.exists?("./.env")
+    return if File.exist?("./.env")
 
     env_file_path = File.join(File.dirname(__FILE__), '.env')
     if !ENV['STRIPE_SECRET_KEY'] && !File.exist?("./.env")

--- a/prebuilt-checkout-page/server/ruby/config_helper.rb
+++ b/prebuilt-checkout-page/server/ruby/config_helper.rb
@@ -191,7 +191,7 @@ class ConfigHelper
       DOC
     end
 
-    if !File.exists?(File.join(static_dir_path, 'index.html'))
+    if !File.exist?(File.join(static_dir_path, 'index.html'))
       if static_dir == ''
         puts <<~DOC
           No value set for STATIC_DIR. If this sample was installed with the
@@ -310,7 +310,7 @@ class ConfigHelper
 
   def dotenv_exists?
     puts "Checking that `.env` exists..."
-    return if File.exists?("./.env")
+    return if File.exist?("./.env")
 
     env_file_path = File.join(File.dirname(__FILE__), '.env')
     if !ENV['STRIPE_SECRET_KEY'] && !File.exist?("./.env")


### PR DESCRIPTION
A couple of CI jobs for Ruby samples are failing since File.exists? has been removed in Ruby 3.2. This PR replaces them with `File.exist?`.

Failing CI run example: https://github.com/stripe-samples/accept-a-payment/actions/runs/3830094652
See also: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/