### PR TITLE
An experiment: ignore patch version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,10 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      # ignore all patch updates except security updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'npm'
     directory: '/custom-payment-flow/server/node-typescript/'
     schedule:


### PR DESCRIPTION
Since we don't need to follow tiny updates, I'd like to update the Dependabot settings. To make sure it works, I'd like to make one sample app ignore patch version updates with this PR. According to the documentation, this ignores patch version updates but still makes pull requests for security fixes if the repo's security updates are enabled.

See also:
* https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore