### PR TITLE
Auto-merge major version updates, too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,7 @@ jobs:
            contains(steps.metadata.outputs.dependency-names, 'Stripe.net') ||
            contains(steps.metadata.outputs.dependency-names, 'com.stripe:stripe-java') ||
            contains(steps.metadata.outputs.dependency-names, 'stripe/stripe-php') ||
-           contains(steps.metadata.outputs.dependency-names, 'stripe')) &&
-           steps.metadata.outputs.update-type == 'version-update:semver-minor'
+           contains(steps.metadata.outputs.dependency-names, 'stripe'))
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
I changed the condition so that it enables auto-merge for major/patch version updates. Since we have been running tests before auto-merging since #1385 was merged, we can also merge major version updates automatically as long as the tests pass.

I expect this change will make the following kind of PRs merged:

* major version updates like [this](https://github.com/stripe-samples/accept-a-payment/pull/1466)
* minor version updates like [this](https://github.com/stripe-samples/accept-a-payment/pull/1492)