### PR TITLE
ci.yml: Use the shell-keyword `[[` instead of the shell-builtin `[` to prevent word splitting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
         run: |
           prefix="${{ matrix.target.sample }}/server/${{ matrix.runtime.server_type }}"
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ] || \
-            [ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]
+          if [[ "${{ github.ref }}" = "refs/heads/main" ]] || \
+            [[ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]]
           then echo 'running=true' >> $GITHUB_OUTPUT
           fi
 
@@ -170,8 +170,8 @@ jobs:
         run: |
           prefix="${{ matrix.target.sample }}/client/${{ matrix.implementation.client_type }}"
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ] || \
-            [ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]
+          if [[ "${{ github.ref }}" = "refs/heads/main" ]] || \
+            [[ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]]
           then echo 'running=true' >> $GITHUB_OUTPUT
           fi
 
@@ -247,8 +247,8 @@ jobs:
         run: |
           prefix="${{ matrix.target.sample }}/client/${{ matrix.implementation.client_type }}"
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ] || \
-            [ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]
+          if [[ "${{ github.ref }}" = "refs/heads/main" ]] || \
+            [[ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]]
           then echo 'running=true' >> $GITHUB_OUTPUT
           fi
 
@@ -310,8 +310,8 @@ jobs:
         run: |
           prefix="custom-payment-flow/client/android-kotlin"
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ] && \
-            [ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]
+          if [[ "${{ github.ref }}" = "refs/heads/main" ]] || \
+            [[ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]]
           then echo 'running=true' >> $GITHUB_OUTPUT
           fi
 
@@ -332,8 +332,8 @@ jobs:
         run: |
           prefix="custom-payment-flow/client/ios-swiftui"
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ] && \
-            [ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]
+          if [[ "${{ github.ref }}" = "refs/heads/main" ]] || \
+            [[ $(echo "${{ needs.changed_files.outputs.files }}" | grep -E "^${prefix}") ]]
           then echo 'running=true' >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Since the `needs.changed_files.outputs.files` could contain whitespaces (like `\n`), [word splitting](https://www.baeldung.com/linux/bash-single-vs-double-brackets#6-word-splitting) would break expressions inside `[` and cause errors like the following. When this error occurs, the tests for the job won't run.

![image](https://user-images.githubusercontent.com/43346/218311277-1172cf43-2a3a-4087-b383-c3f68d7fbe73.png)

> /home/runner/work/_temp/1d6e553c-f4ba-433c-a1f4-52bfa477e7c8.sh: line 6: [: prebuilt-checkout-page/client/vue-cva/package.json: binary operator expected

https://github.com/stripe-samples/accept-a-payment/actions/runs/3953997934/jobs/6770873380#step:2:16

 The shell-builtin `[[`used in this PR prevents word splitting and errors similar to the above will be fixed.