### PR TITLE
Fix failing e2e tests

### DIFF
--- a/spec/capybara_support.rb
+++ b/spec/capybara_support.rb
@@ -5,7 +5,8 @@ require 'capybara-screenshot/rspec'
 Capybara.server_host = Socket.ip_address_list.detect(&:ipv4_private?).ip_address
 
 Capybara.register_driver :chrome do |app|
-  opts = {browser: :chrome, url: ENV.fetch('SELENIUM_URL', 'http://selenium:4444/wd/hub')}
+  browser_options = Selenium::WebDriver::Chrome::Options.new
+  opts = {browser: :remote, options: browser_options, url: ENV.fetch('SELENIUM_URL', 'http://selenium:4444/wd/hub')}
   Capybara::Selenium::Driver.new(app, **opts)
 end
 


### PR DESCRIPTION
It turned out that the [Chrome driver does not support :url option from selenium-4.8.0](https://github.com/SeleniumHQ/selenium/commit/08ee2d9fcf952aff3dc9752d2399e9474c356843). It causes errors [like this](https://github.com/hibariya/accept-a-payment/actions/runs/4155994626/jobs/7189474683#step:5:263). Changed to use the Remote driver instead to fix it.

