### PR TITLE
Update Stripe API to 2022-11-15

### DIFF
--- a/custom-payment-flow/server/node-typescript/src/server.ts
+++ b/custom-payment-flow/server/node-typescript/src/server.ts
@@ -9,7 +9,7 @@ import express from "express";
 
 import Stripe from "stripe";
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2022-08-01",
+  apiVersion: "2022-11-15",
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/accept-a-payment",
     url: "https://github.com/stripe-samples",

--- a/payment-element/server/node-typescript/src/server.ts
+++ b/payment-element/server/node-typescript/src/server.ts
@@ -8,7 +8,7 @@ import express from "express";
 
 import Stripe from "stripe";
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2020-08-27",
+  apiVersion: "2022-11-15",
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/accept-a-payment",
     url: "https://github.com/stripe-samples",


### PR DESCRIPTION
Fixes errors like this: https://github.com/stripe-samples/accept-a-payment/actions/runs/4165270933/jobs/7208052093#step:6:120