### PR TITLE
Uncheck Stripe Pass for testing

### DIFF
--- a/spec/prebuilt_checkout_page_e2e_spec.rb
+++ b/spec/prebuilt_checkout_page_e2e_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe 'Custom payment flow', type: :system do
     select 'United States', from: 'billingCountry'
     fill_in 'billingPostalCode', with: '10000'
 
+    # in case it checked by default
+    uncheck 'enableStripePass', allow_label_click: true
+
     click_on 'Pay'
 
     expect(page).to have_content 'Your payment succeeded'


### PR DESCRIPTION
Hi, I noticed that the Stripe Link feature is enabled by default in some environments and has been causing the failure of the test. I fixed it by unchecking the checkbox.

![screenshot_2023-04-26-08-46-33 271](https://user-images.githubusercontent.com/43346/234564564-5b60f920-8875-48db-b63a-afcc6c8025ec.png)
