### PR TITLE
Point to the Tax API for tax calculation in our README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository includes examples of 3 types of integration.
 | Small refactor to collect recurring payments. | Large refactor to collect recurring payments. | Large refactor to collect recurring payments. |
 | Input validation and error handling built in. | Input validation built-in but you must implement error handling. | Implement your own input validation and error handling. |
 | Localized in 25+ languages. | Localized in 25+ languages. |Implement your own localization. |
-| Automate calculation and collection of sales tax, VAT and GST with one line of code. | Implement your own logic to automate taxes on your transactions. | Implement your own logic to automate taxes on your transactions. |
+| Automate calculation and collection of sales tax, VAT and GST with one line of code. | Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom) | Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom) |
 
 
 ### Payment Method Type Support


### PR DESCRIPTION
Since March 27th, the Stripe Tax API for implementing tax calculation for custom payment flows is live. This API is intended both for Stripe Elements users as well as for users having a custom payment flow. Let's point to it from the README.