### PR TITLE
Open Dependabot PRs only for minor or major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,17 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'bundler'
     directory: '/prebuilt-checkout-page/server/ruby/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # python dependencies
   - package-ecosystem: 'pip'
@@ -23,11 +29,17 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'pip'
     directory: '/prebuilt-checkout-page/server/python/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # php dependencies
   - package-ecosystem: 'composer'
@@ -35,11 +47,17 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'composer'
     directory: '/prebuilt-checkout-page/server/php/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # node dependencies
   - package-ecosystem: 'npm'
@@ -48,7 +66,6 @@ updates:
       interval: 'weekly'
       day: 'thursday'
     ignore:
-      # ignore all patch updates except security updates
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'npm'
@@ -56,41 +73,65 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'npm'
     directory: '/prebuilt-checkout-page/server/node/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'npm'
     directory: '/custom-payment-flow/client/react-cra/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'npm'
     directory: '/payment-element/client/react-cra/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'npm'
     directory: '/prebuilt-checkout-page/client/react-cra/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'npm'
     directory: '/prebuilt-checkout-page/client/vue-cva/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # go dependencies
   - package-ecosystem: 'gomod'
     directory: '/custom-payment-flow/server/go/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'gomod'
     directory: '/prebuilt-checkout-page/server/go/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # java dependencies
   - package-ecosystem: 'maven'
@@ -98,11 +139,17 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'maven'
     directory: '/prebuilt-checkout-page/server/java/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # dotnet dependencies
   - package-ecosystem: 'nuget'
@@ -110,8 +157,14 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: 'nuget'
     directory: '/prebuilt-checkout-page/server/dotnet/'
     schedule:
       interval: 'weekly'
       day: 'thursday'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
I have updated `dependabot.yml` so that Dependabot opens PRs only for major/minor updates. To allow security updates ([like this](https://github.com/hibariya/accept-a-payment/pull/1749)), I recommend enabling `Dependabot security updates` on the repository settings if we haven't enabled it.

![image](https://github.com/stripe-samples/accept-a-payment/assets/43346/6bf7e40d-a425-4deb-b4bc-c91b0c1f8f4a)
