### PR TITLE
Use 0.0.0.0 as the host to run Vite in containers

### DIFF
--- a/custom-payment-flow/client/react-cra/vite.config.mjs
+++ b/custom-payment-flow/client/react-cra/vite.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
   ],
   server: {
     port: 3000,
+    host: "0.0.0.0",
     proxy: {
         '/api': {
           target: 'http://localhost:4242',
@@ -19,3 +20,4 @@ export default defineConfig({
     outDir: "build",
   },
 })
+

--- a/payment-element/client/react-cra/vite.config.mjs
+++ b/payment-element/client/react-cra/vite.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
   ],
   server: {
     port: 3000,
+    host: "0.0.0.0",
     proxy: {
         '/api': {
           target: 'http://localhost:4242',

--- a/prebuilt-checkout-page/client/react-cra/vite.config.mjs
+++ b/prebuilt-checkout-page/client/react-cra/vite.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
   ],
   server: {
     port: 3000,
+    host: "0.0.0.0",
     proxy: {
         '/api': {
           target: 'http://localhost:4242',


### PR DESCRIPTION
It seems we need to specify it explicitly these days, otherwise E2E test fails. I believe this change is harmless for users.
There are another couple of CI issues. Since they are unrelated to this one, I will fix them in separate PRs.