### PR TITLE
Add PayPal button examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This repository includes examples of 3 types of integration.
 |Link| ✅ | ✅ |  |
 |Multibanco| ✅ | ✅ |  |
 |OXXO| ✅ | ✅ | ✅ |
+|PayPal| ✅ | ✅ | ✅ |
 |Przelewy24 (P24)| ✅ | ✅ | ✅ |
 |SEPA Direct Debit| ✅ | ✅ | ✅ |
 |Sofort| ✅ | ✅ | ✅ |

--- a/custom-payment-flow/client/html/index.html
+++ b/custom-payment-flow/client/html/index.html
@@ -81,6 +81,7 @@
         <li><a href="/apple-pay.html">Apple Pay</a></li>
         <li><a href="/google-pay.html">Google Pay</a></li>
         <li><a href="/grabpay.html">GrabPay</a></li>
+        <li><a href="/paypal.html">PayPal (Express Checkout Element)</a></li>
       </ul>
     </main>
   </body>

--- a/custom-payment-flow/client/html/index.html
+++ b/custom-payment-flow/client/html/index.html
@@ -81,7 +81,10 @@
         <li><a href="/apple-pay.html">Apple Pay</a></li>
         <li><a href="/google-pay.html">Google Pay</a></li>
         <li><a href="/grabpay.html">GrabPay</a></li>
-        <li><a href="/paypal.html">PayPal (Express Checkout Element)</a></li>
+      </ul>
+      <h4>Express Checkout Element</h4>
+      <ul>
+        <li><a href="/paypal.html">PayPal</a></li>
       </ul>
     </main>
   </body>

--- a/custom-payment-flow/client/html/paypal.html
+++ b/custom-payment-flow/client/html/paypal.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>PayPal Express Checkout Element</title>
+
+    <link rel="stylesheet" href="css/base.css" />
+    <script src="https://js.stripe.com/v3/"></script>
+
+    <script src="/utils.js" defer></script>
+    <script src="/paypal.js" defer></script>
+  </head>
+  <body>
+    <main>
+      <a href="/">home</a>
+      <h1>PayPal ECE</h1>
+
+      <div id="express-checkout-element">
+        <!-- Express Checkout Element will be inserted here -->
+      </div>
+      <div id="error-message">
+        <!-- Display an error message to your customers here -->
+      </div>
+    </main>
+  </body>
+</html>

--- a/custom-payment-flow/client/html/paypal.html
+++ b/custom-payment-flow/client/html/paypal.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <title>PayPal Express Checkout Element</title>
+    <title>PayPal Button</title>
 
     <link rel="stylesheet" href="css/base.css" />
     <script src="https://js.stripe.com/v3/"></script>
@@ -15,7 +15,14 @@
   <body>
     <main>
       <a href="/">home</a>
-      <h1>PayPal ECE</h1>
+      <h1>PayPal Button in Express Checkout Element</h1>
+      <p>
+        Before you start, we recommend you create a
+        <a href="https://developer.paypal.com/tools/sandbox/accounts/"
+          >PayPal Sandbox account</a
+        >
+        to test your integration.
+      </p>
 
       <div id="express-checkout-element">
         <!-- Express Checkout Element will be inserted here -->

--- a/custom-payment-flow/client/html/paypal.js
+++ b/custom-payment-flow/client/html/paypal.js
@@ -1,0 +1,94 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  // Load the publishable key from the server. The publishable key
+  // is set in your .env file. In practice, most users hard code the
+  // publishable key when initializing the Stripe object.
+  const {publishableKey} = await fetch('/config').then((r) => r.json());
+  if (!publishableKey) {
+    addMessage(
+      'No publishable key returned from the server. Please check `.env` and try again'
+    );
+    alert('Please set your Stripe publishable API key in the .env file');
+  }
+
+  // 1. Initialize Stripe
+  const stripe = Stripe(publishableKey, {
+    apiVersion: '2024-06-20',
+  });
+
+  MODE = 'setup';
+  AMOUNT = 1400;
+  CURRENCY = 'usd';
+
+  // 3. Create a PaymentRequestButton element
+  const elements = stripe.elements({
+    mode: MODE,
+    // amount: AMOUNT,
+    currency: CURRENCY,
+  });
+
+  const expressCheckoutElement = elements.create('expressCheckout');
+  expressCheckoutElement.mount('#express-checkout-element');
+
+  expressCheckoutElement.on('click', (event) => {
+    const options = {
+      phoneNumberRequired: true,
+    };
+    event.resolve(options);
+  });
+
+  const handleError = (error) => {
+    const messageContainer = document.querySelector('#error-message');
+    messageContainer.textContent = error.message;
+  };
+
+  expressCheckoutElement.on('confirm', async (event) => {
+    const {error: submitError} = await elements.submit();
+    if (submitError) {
+      handleError(submitError);
+      return;
+    }
+
+    const {error: backendError, clientSecret} = await fetch('/create-intent', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        currency: CURRENCY,
+        amount: AMOUNT,
+        mode: MODE,
+      }),
+    }).then((r) => r.json());
+
+    if (MODE === 'setup') {
+      const {error} = await stripe.confirmSetup({
+        // `elements` instance used to create the Express Checkout Element
+        elements,
+        // `clientSecret` from the created PaymentIntent
+        clientSecret,
+        confirmParams: {
+          return_url: 'https://example.com/order/123/complete',
+        },
+      });
+    } else if (MODE === 'payment') {
+      const {error} = await stripe.confirmPayment({
+        // `elements` instance used to create the Express Checkout Element
+        elements,
+        // `clientSecret` from the created PaymentIntent
+        clientSecret,
+        confirmParams: {
+          return_url: 'https://example.com/order/123/complete',
+        },
+      });
+    }
+
+    if (error) {
+      // This point is only reached if there's an immediate error when
+      // confirming the payment. Show the error to your customer (for example, payment details incomplete)
+      handleError(error);
+    } else {
+      // The payment UI automatically closes with a success animation.
+      // Your customer is redirected to your `return_url`.
+    }
+  });
+});

--- a/custom-payment-flow/server/node-typescript/src/server.ts
+++ b/custom-payment-flow/server/node-typescript/src/server.ts
@@ -86,7 +86,7 @@ app.post(
   async (req: express.Request, res: express.Response): Promise<void> => {
     const { currency, paymentMethodType, paymentMethodOptions }: { currency: string, paymentMethodType: string, paymentMethodOptions?: object } = req.body;
 
-    let orderAmount = 1400;
+    let orderAmount = 5999;
     let params: Stripe.PaymentIntentCreateParams;
 
     // Each payment method type has support for different currencies. In order to

--- a/custom-payment-flow/server/node/server.js
+++ b/custom-payment-flow/server/node/server.js
@@ -82,7 +82,7 @@ app.post('/create-payment-intent', async (req, res) => {
   // at https://dashboard.stripe.com/settings/payment_methods.
   //
   // Some example payment method types include `card`, `ideal`, and `link`.
-  let orderAmount = 1400;
+  let orderAmount = 5999;
   let params = {};
 
   if (calculateTax) {
@@ -149,47 +149,6 @@ app.post('/create-payment-intent', async (req, res) => {
     res.send({
       clientSecret: paymentIntent.client_secret,
       nextAction: paymentIntent.next_action,
-    });
-  } catch (e) {
-    return res.status(400).send({
-      error: {
-        message: e.message,
-      },
-    });
-  }
-});
-
-app.post('/create-intent', async (req, res) => {
-  const {currency, amount, mode} = req.body;
-
-
-  // Create a PaymentIntent with the amount, currency, and a payment method type.
-  //
-  // See the documentation [0] for the full list of supported parameters.
-  //
-  // [0] https://stripe.com/docs/api/payment_intents/create
-  try {
-    var intent;
-    if (mode === "payment") {
-
-    intent = await stripe.paymentIntents.create({
-      amount: amount,
-      currency: currency,
-      automatic_payment_methods: {
-        enabled: true,
-      },
-    });
-  } else if (mode === "setup") {
-    intent = await stripe.setupIntents.create({
-      automatic_payment_methods: {
-        enabled: true,
-      },
-    });
-  }
-
-    // Send publishable key and PaymentIntent details to client
-    res.send({
-      clientSecret: intent.client_secret
     });
   } catch (e) {
     return res.status(400).send({


### PR DESCRIPTION
The PayPal button is available in Stripe's Express Checkout Element (ECE). Added an example to `custom-payment-flow`. Note that the amounts in ECE and on the backend need to match, so I had to update the `node` backend to the commonly used amount of `59.99`.