### PR TITLE
Add Adaptive Pricing to elements-with-checkout-sessions

### DIFF
--- a/.github/workflows/ci_e2e.yaml
+++ b/.github/workflows/ci_e2e.yaml
@@ -75,6 +75,7 @@ jobs:
           DOMAIN=${{ matrix.implementation.domain }}
           PRICE=${{ secrets.TEST_PRICE }}
           PAYMENT_METHOD_TYPES="card"
+          CUSTOMER_EMAIL="test+location_FR@example.com"
           EOF
 
           configure_docker_compose_for_integration "${{ matrix.target.sample }}" node ../../client/${{ matrix.implementation.client_type }} node:latest

--- a/elements-with-checkout-sessions/.env.example
+++ b/elements-with-checkout-sessions/.env.example
@@ -5,3 +5,7 @@ STATIC_DIR=../../client/html
 # For React/Vue clients, set to the dev server URL (e.g. http://localhost:3000)
 DOMAIN=http://localhost:4242
 PORT=4242
+# Set CUSTOMER_EMAIL to test Adaptive Pricing locally.
+# The +location_XX suffix simulates a customer from country XX (ISO code).
+# When set, the Currency Selector Element shows local currency options.
+# CUSTOMER_EMAIL=test+location_FR@example.com

--- a/elements-with-checkout-sessions/client/html/index.css
+++ b/elements-with-checkout-sessions/client/html/index.css
@@ -49,6 +49,22 @@ form {
   margin-top: 16px;
 }
 
+#email-readonly {
+  background-color: #f9f9f9;
+  border: 1px solid #e5e5e5;
+  border-radius: 5px;
+  padding: 0.75rem;
+  color: #30313d;
+  margin-top: 0.25rem;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  height: 44px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 #email {
   border-radius: 5px;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.03), 0px 3px 6px rgba(0, 0, 0, 0.02);

--- a/elements-with-checkout-sessions/client/html/index.html
+++ b/elements-with-checkout-sessions/client/html/index.html
@@ -12,11 +12,14 @@
   <body>
     <!-- Display a payment form -->
     <form id="payment-form">
-      <label>
-        Email
-        <input type="email" id="email"
-      /></label>
-      <div id="email-errors"></div>
+      <div id="email-section">
+        <label>
+          Email
+          <input type="email" id="email"
+        /></label>
+        <div id="email-readonly" class="hidden"></div>
+        <div id="email-errors"></div>
+      </div>
       <h4>Billing address</h4>
       <div id="address-element">
         <!--Stripe.js injects the Address Element-->
@@ -24,6 +27,9 @@
       <h4>Payment</h4>
       <div id="payment-element">
         <!--Stripe.js injects the Payment Element-->
+      </div>
+      <div id="currency-selector">
+        <!--Stripe.js injects the Currency Selector Element-->
       </div>
       <button id="submit">
         <div class="spinner hidden" id="spinner"></div>

--- a/elements-with-checkout-sessions/client/html/index.js
+++ b/elements-with-checkout-sessions/client/html/index.js
@@ -1,8 +1,10 @@
 let checkout;
 let actions;
+let emailAlreadySet = false;
 initialize();
 const emailInput = document.getElementById("email");
 const emailErrors = document.getElementById("email-errors");
+const emailSection = document.getElementById("email-section");
 
 const validateEmail = async (email) => {
   const updateResult = await actions.updateEmail(email);
@@ -15,7 +17,6 @@ document
   .querySelector("#payment-form")
   .addEventListener("submit", handleSubmit);
 
-// Fetches a Checkout Session and captures the client secret
 async function initialize() {
   const { publishableKey } = await fetch("/config").then((r) => r.json());
   const stripe = Stripe(publishableKey);
@@ -33,10 +34,10 @@ async function initialize() {
   checkout = stripe.initCheckoutElementsSdk({
     clientSecret: promise,
     elementsOptions: { appearance },
+    adaptivePricing: { allowed: true },
   });
 
   checkout.on('change', (session) => {
-    // Handle changes to the checkout session
     document.getElementById('submit').disabled = !session.canConfirm;
   });
 
@@ -47,6 +48,16 @@ async function initialize() {
     document.querySelector("#button-text").textContent = `Pay ${
       session.total.total.amount
     } now`;
+
+    // If the session already has a customer email (e.g. from customer_email
+    // param on the server), show it as read-only instead of an editable input.
+    if (session.email) {
+      emailAlreadySet = true;
+      emailInput.style.display = "none";
+      const readOnly = document.getElementById("email-readonly");
+      readOnly.textContent = session.email;
+      readOnly.classList.remove("hidden");
+    }
   } else {
     showMessage("Failed to initialize payment form. Please refresh.");
     document.querySelector("#submit").disabled = true;
@@ -54,12 +65,12 @@ async function initialize() {
   }
 
   emailInput.addEventListener("input", () => {
-    // Clear any validation errors
     emailErrors.textContent = "";
     emailInput.classList.remove("error");
   });
 
   emailInput.addEventListener("blur", async () => {
+    if (emailAlreadySet) return;
     const newEmail = emailInput.value;
     if (!newEmail) {
       return;
@@ -77,29 +88,29 @@ async function initialize() {
 
   const paymentElement = checkout.createPaymentElement();
   paymentElement.mount("#payment-element");
+
+  const currencySelectorElement = checkout.createCurrencySelectorElement();
+  currencySelectorElement.mount("#currency-selector");
 }
 
 async function handleSubmit(e) {
   e.preventDefault();
   setLoading(true);
 
-  const email = document.getElementById("email").value;
-  const { isValid, message } = await validateEmail(email);
-  if (!isValid) {
-    emailInput.classList.add("error");
-    emailErrors.textContent = message;
-    showMessage(message);
-    setLoading(false);
-    return;
+  if (!emailAlreadySet) {
+    const email = document.getElementById("email").value;
+    const { isValid, message } = await validateEmail(email);
+    if (!isValid) {
+      emailInput.classList.add("error");
+      emailErrors.textContent = message;
+      showMessage(message);
+      setLoading(false);
+      return;
+    }
   }
 
   const confirmResult = await actions.confirm();
 
-  // This point will only be reached if there is an immediate error when
-  // confirming the payment. Otherwise, your customer will be redirected to
-  // your `return_url`. For some payment methods like iDEAL, your customer will
-  // be redirected to an intermediate site first to authorize the payment, then
-  // redirected to the `return_url`.
   if (confirmResult.type === 'error') {
     showMessage(confirmResult.error.message);
   }
@@ -121,10 +132,8 @@ function showMessage(messageText) {
   }, 4000);
 }
 
-// Show a spinner on payment submission
 function setLoading(isLoading) {
   if (isLoading) {
-    // Disable the button and show a spinner
     document.querySelector("#submit").disabled = true;
     document.querySelector("#spinner").classList.remove("hidden");
     document.querySelector("#button-text").classList.add("hidden");

--- a/elements-with-checkout-sessions/client/react-cra/src/App.css
+++ b/elements-with-checkout-sessions/client/react-cra/src/App.css
@@ -45,6 +45,22 @@ form {
   margin-top: 16px;
 }
 
+#email-readonly {
+  background-color: #f9f9f9;
+  border: 1px solid #e5e5e5;
+  border-radius: 5px;
+  padding: 0.75rem;
+  color: #30313d;
+  margin-top: 0.25rem;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  height: 44px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 #email {
   border-radius: 5px;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.03), 0px 3px 6px rgba(0, 0, 0, 0.02);

--- a/elements-with-checkout-sessions/client/react-cra/src/App.jsx
+++ b/elements-with-checkout-sessions/client/react-cra/src/App.jsx
@@ -42,6 +42,7 @@ const App = () => {
           options={{
             clientSecret,
             elementsOptions: { appearance },
+            adaptivePricing: { allowed: true },
           }}
         >
           <Routes>

--- a/elements-with-checkout-sessions/client/react-cra/src/CheckoutForm.jsx
+++ b/elements-with-checkout-sessions/client/react-cra/src/CheckoutForm.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import {
   PaymentElement,
   BillingAddressElement,
+  CurrencySelectorElement,
   useCheckout
 } from '@stripe/react-stripe-js/checkout';
 
@@ -67,6 +68,7 @@ const CheckoutForm = () => {
     );
   }
 
+  const emailAlreadySet = !!checkoutState.checkout.email;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -74,21 +76,18 @@ const CheckoutForm = () => {
     const {checkout} = checkoutState;
     setIsSubmitting(true);
 
-    const { isValid, message } = await validateEmail(email, checkout);
-    if (!isValid) {
-      setEmailError(message);
-      setMessage(message);
-      setIsSubmitting(false);
-      return;
+    if (!emailAlreadySet) {
+      const { isValid, message } = await validateEmail(email, checkout);
+      if (!isValid) {
+        setEmailError(message);
+        setMessage(message);
+        setIsSubmitting(false);
+        return;
+      }
     }
 
     const confirmResult = await checkout.confirm();
 
-    // This point will only be reached if there is an immediate error when
-    // confirming the payment. Otherwise, your customer will be redirected to
-    // your `return_url`. For some payment methods like iDEAL, your customer will
-    // be redirected to an intermediate site first to authorize the payment, then
-    // redirected to the `return_url`.
     if (confirmResult.type === 'error') {
       setMessage(confirmResult.error.message);
     }
@@ -98,17 +97,25 @@ const CheckoutForm = () => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <EmailInput
-        checkout={checkoutState.checkout}
-        email={email}
-        setEmail={setEmail}
-        error={emailError}
-        setError={setEmailError}
-      />
+      {emailAlreadySet ? (
+        <>
+          <label>Email</label>
+          <div id="email-readonly">{checkoutState.checkout.email}</div>
+        </>
+      ) : (
+        <EmailInput
+          checkout={checkoutState.checkout}
+          email={email}
+          setEmail={setEmail}
+          error={emailError}
+          setError={setEmailError}
+        />
+      )}
       <h4>Billing address</h4>
       <BillingAddressElement id="address-element" />
       <h4>Payment</h4>
       <PaymentElement id="payment-element" />
+      <CurrencySelectorElement id="currency-selector" />
       <button disabled={!checkoutState.checkout.canConfirm || isSubmitting} id="submit">
         {isSubmitting ? (
           <div className="spinner"></div>
@@ -116,7 +123,6 @@ const CheckoutForm = () => {
           `Pay ${checkoutState.checkout.total.total.amount} now`
         )}
       </button>
-      {/* Show any error or success messages */}
       {message && <div id="payment-message">{message}</div>}
     </form>
   );

--- a/elements-with-checkout-sessions/server/dotnet/Server.cs
+++ b/elements-with-checkout-sessions/server/dotnet/Server.cs
@@ -125,7 +125,13 @@ namespace server.Controllers
                     },
                     Mode = "payment",
                     ReturnUrl = domain + "/complete?session_id={CHECKOUT_SESSION_ID}",
+                    AdaptivePricing = new SessionAdaptivePricingOptions { Enabled = true },
                 };
+                var customerEmail = Environment.GetEnvironmentVariable("CUSTOMER_EMAIL");
+                if (!string.IsNullOrEmpty(customerEmail))
+                {
+                    options.CustomerEmail = customerEmail;
+                }
                 Session session = _client.V1.Checkout.Sessions.Create(options);
 
                 return Json(new {clientSecret = session.ClientSecret});

--- a/elements-with-checkout-sessions/server/go/server.go
+++ b/elements-with-checkout-sessions/server/go/server.go
@@ -101,6 +101,12 @@ func createCheckoutSession(sc *stripe.Client, w http.ResponseWriter, r *http.Req
       },
     },
     Mode: stripe.String("payment"),
+    AdaptivePricing: &stripe.CheckoutSessionCreateAdaptivePricingParams{
+      Enabled: stripe.Bool(true),
+    },
+  }
+  if os.Getenv("CUSTOMER_EMAIL") != "" {
+    params.CustomerEmail = stripe.String(os.Getenv("CUSTOMER_EMAIL"))
   }
 
   s, err := sc.V1CheckoutSessions.Create(context.TODO(), params)

--- a/elements-with-checkout-sessions/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/elements-with-checkout-sessions/server/java/src/main/java/com/stripe/sample/Server.java
@@ -67,7 +67,7 @@ public class Server {
     post("/create-checkout-session", (request, response) -> {
       try {
         String YOUR_DOMAIN = env("DOMAIN", "http://localhost:" + serverPort);
-        SessionCreateParams params =
+        SessionCreateParams.Builder paramsBuilder =
           SessionCreateParams.builder()
             .setUiMode(SessionCreateParams.UiMode.ELEMENTS)
             .setMode(SessionCreateParams.Mode.PAYMENT)
@@ -86,7 +86,15 @@ public class Server {
                     .setUnitAmount(2000L)
                     .build())
                 .build())
-            .build();
+            .setAdaptivePricing(
+              SessionCreateParams.AdaptivePricing.builder()
+                .setEnabled(true)
+                .build());
+        String customerEmail = System.getenv("CUSTOMER_EMAIL");
+        if (customerEmail != null && !customerEmail.isEmpty()) {
+          paramsBuilder.setCustomerEmail(customerEmail);
+        }
+        SessionCreateParams params = paramsBuilder.build();
 
         Session session = client.v1().checkout().sessions().create(params);
 

--- a/elements-with-checkout-sessions/server/node/server.js
+++ b/elements-with-checkout-sessions/server/node/server.js
@@ -38,7 +38,6 @@ app.post("/create-checkout-session", async (req, res) => {
   try {
     const session = await client.checkout.sessions.create({
       ui_mode: "elements",
-      // You can also use an existing Price: { price: 'price_xxx', quantity: 1 }
       line_items: [
         {
           price_data: {
@@ -52,6 +51,8 @@ app.post("/create-checkout-session", async (req, res) => {
         },
       ],
       mode: "payment",
+      adaptive_pricing: { enabled: true },
+      ...(process.env.CUSTOMER_EMAIL && { customer_email: process.env.CUSTOMER_EMAIL }),
       return_url: `${YOUR_DOMAIN}/complete?session_id={CHECKOUT_SESSION_ID}`,
     });
 

--- a/elements-with-checkout-sessions/server/php/public/create-checkout-session.php
+++ b/elements-with-checkout-sessions/server/php/public/create-checkout-session.php
@@ -32,7 +32,8 @@ try {
     ]],
     'mode' => 'payment',
     'return_url' => $YOUR_DOMAIN . '/complete?session_id={CHECKOUT_SESSION_ID}',
-  ]);
+    'adaptive_pricing' => ['enabled' => true],
+  ] + (getenv('CUSTOMER_EMAIL') ? ['customer_email' => getenv('CUSTOMER_EMAIL')] : []));
 
   echo json_encode(array('clientSecret' => $checkout_session->client_secret));
 } catch (Exception $e) {

--- a/elements-with-checkout-sessions/server/python/server.py
+++ b/elements-with-checkout-sessions/server/python/server.py
@@ -63,6 +63,8 @@ def create_checkout_session():
             ],
             'mode': 'payment',
             'return_url': YOUR_DOMAIN + '/complete?session_id={CHECKOUT_SESSION_ID}',
+            'adaptive_pricing': {'enabled': True},
+            **(({'customer_email': os.environ['CUSTOMER_EMAIL']} if os.environ.get('CUSTOMER_EMAIL') else {})),
         })
 
         return jsonify(clientSecret=session.client_secret)

--- a/elements-with-checkout-sessions/server/ruby/server.rb
+++ b/elements-with-checkout-sessions/server/ruby/server.rb
@@ -52,6 +52,8 @@ post '/create-checkout-session' do
       }],
       mode: 'payment',
       return_url: YOUR_DOMAIN + '/complete?session_id={CHECKOUT_SESSION_ID}',
+      adaptive_pricing: { enabled: true },
+      **(ENV['CUSTOMER_EMAIL'] ? { customer_email: ENV['CUSTOMER_EMAIL'] } : {}),
     })
 
     { clientSecret: session.client_secret }.to_json

--- a/spec/elements_with_checkout_sessions_e2e_spec.rb
+++ b/spec/elements_with_checkout_sessions_e2e_spec.rb
@@ -16,37 +16,29 @@ RSpec.describe 'Elements with Checkout Sessions', type: :system do
       '#address-element iframe[title="Secure address input frame"]', wait: 30
     )
 
-    # Email is a plain HTML input on the merchant's page (not inside a Stripe
-    # iframe). After filling it, Tab moves focus to the next field, which
-    # triggers the blur handler that calls actions.updateEmail().
-    email_input = find('#email')
-    email_input.fill_in with: "test#{SecureRandom.hex(4)}@example.com"
-    email_input.send_keys(:tab)
+    # Wait for the Currency Selector Element to render. The server sets
+    # customer_email with +location_FR to simulate a French customer,
+    # which triggers EUR/USD currency options.
+    expect(page).to have_css(
+      '#currency-selector iframe[title="Secure currency selector"]', wait: 30
+    )
+
+    # Email is pre-set via customer_email on the session, so the email
+    # input should be hidden. No need to fill it.
 
     # Fill billing address fields inside the Billing Address Element iframe.
-    # Field names verified from iframe DOM inspection:
-    #   input[name="name"]               - Full name
-    #   select[name="country"]           - Country or region
-    #   input[name="addressLine1"]       - Address line 1
-    #   input[name="addressLine2"]       - Address line 2
-    #   input[name="locality"]           - City
-    #   select[name="administrativeArea"] - State
-    #   input[name="postalCode"]         - ZIP code
+    # Field names verified from iframe DOM inspection.
     within_frame first('#address-element iframe[title="Secure address input frame"]') do
       fill_in 'name', with: 'Jenny Rosen'
       select 'United States', from: 'country'
 
-      # Typing in addressLine1 triggers a Google autocomplete dropdown.
-      # Escape dismisses the dropdown; Tab blurs the field which causes
-      # the address element to expand individual city/state/zip fields.
-      # (Verified: Escape alone leaves expanded fields hidden; Tab is
-      # required to trigger the switch from autocomplete to manual mode.)
+      # Typing in addressLine1 triggers Google autocomplete.
+      # Escape dismisses it; Tab expands city/state/zip fields.
       address_field = find('[name="addressLine1"]')
       address_field.fill_in with: '123 Main St'
       address_field.send_keys(:escape)
       address_field.send_keys(:tab)
 
-      # Wait for the expanded fields to become visible
       find('[name="locality"]', wait: 5)
 
       fill_in 'locality', with: 'San Francisco'
@@ -55,15 +47,7 @@ RSpec.describe 'Elements with Checkout Sessions', type: :system do
     end
 
     # Fill card details inside the Payment Element iframe.
-    # The Payment Element renders an accordion with multiple payment methods.
-    # Click "Card" to expand the card form. When the Billing Address Element
-    # is present, the Payment Element does not show country or postal code
-    # fields — only card number, expiry, and CVC.
-    # Field names verified from iframe DOM inspection:
-    #   div[data-value="card"]  - Card accordion tab (always present)
-    #   input[name="number"]    - Card number
-    #   input[name="expiry"]    - Expiry date
-    #   input[name="cvc"]       - CVC
+    # Field names verified from iframe DOM inspection.
     within_frame first('#payment-element iframe[title="Secure payment input frame"]') do
       find('[data-value="card"]').click
 
@@ -71,22 +55,16 @@ RSpec.describe 'Elements with Checkout Sessions', type: :system do
       fill_in 'expiry', with: '12 / 33'
       fill_in 'cvc', with: '123'
 
-      # Uncheck Link "Save my information" if present.
-      # Click the label to toggle the checkbox.
-      # Verified from local DOM: label[for="payment-linkOptInInput"]
+      # Uncheck Link "Save my information" if present
       if page.has_css?('label[for="payment-linkOptInInput"]', wait: 2)
         find('label[for="payment-linkOptInInput"]').click
       end
     end
 
-    # Wait for the Pay button to become enabled. The SDK disables it until
-    # canConfirm is true (all required fields filled + email registered).
     expect(page).to have_button('submit', disabled: false, wait: 10)
 
     find('#submit').click
 
-    # After successful payment the SDK redirects to /complete?session_id=...
-    # which fetches session status and displays the result.
     expect(page).to have_content('Payment succeeded', wait: 30)
   end
 end

--- a/spec/elements_with_checkout_sessions_server_spec.rb
+++ b/spec/elements_with_checkout_sessions_server_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "elements-with-checkout-sessions integration" do
       })
       expect(session.mode).to eq('payment')
       expect(session.line_items.data.length).to be > 0
+      expect(session.adaptive_pricing.enabled).to be true
     end
   end
 


### PR DESCRIPTION
## Summary

Add Adaptive Pricing + Currency Selector to the elements-with-checkout-sessions sample. The motivation is Adaptive Pricing  is a key feature of EwCS over other integration types like EwPI.

<img width="539" height="745" alt="image" src="https://github.com/user-attachments/assets/474c9268-5b5a-4ded-98c7-62590d7cc58e" />

### How it works

1. Server enables `adaptive_pricing: { enabled: true }` on the Checkout Session
2. Server optionally passes `customer_email` from `CUSTOMER_EMAIL` env var (for location simulation in test mode)
3. Client initializes SDK with `adaptivePricing: { allowed: true }`
4. Client mounts `CurrencySelectorElement` which shows local currency options when available
5. Client shows email as read-only when pre-set via `customer_email` 

### Changes

**Server (all 7 languages):** Add `adaptive_pricing: { enabled: true }`, read `CUSTOMER_EMAIL` from env and conditionally pass as `customer_email`

**HTML client:** `adaptivePricing` SDK option, `CurrencySelectorElement`, read-only email when pre-set

**React client:** Same changes using `CurrencySelectorElement` component from `@stripe/react-stripe-js/checkout`

**CI workflow:** Set `CUSTOMER_EMAIL=test+location_FR@example.com` in E2E env to simulate French customer for testing

**Tests:** E2E verifies Currency Selector Element renders, server test asserts `adaptive_pricing.enabled`

### Testing adaptive pricing locally

Set `CUSTOMER_EMAIL` in your `.env`:
```
CUSTOMER_EMAIL=test+location_FR@example.com
```
The `+location_XX` suffix simulates a customer from country XX (ISO code). The Currency Selector Element will show local currency options.

## Test plan
Note some tests not related to EwCS fail. I am trying to fix these as well see this [PR](https://github.com/stripe-samples/accept-a-payment/pull/3100).

- [x] All EwCS E2E tests pass (HTML + react-cra) with Currency Selector Element assertion
- [x] All EwCS server tests pass with adaptive_pricing.enabled assertion
- [x] Manual testing: Currency Selector shows EUR/USD toggle, payment succeeds


https://github.com/user-attachments/assets/6d4a4e05-5f26-44a0-a90d-8548e986c4cc