### PR TITLE
Automatically set correct DOMAIN=http://localhost:3000 for react clients for stripe cli users

### DIFF
--- a/.cli.json
+++ b/.cli.json
@@ -14,7 +14,12 @@
         "go",
         "dotnet",
         "node-typescript"
-      ]
+      ],
+      "clientEnvOverrides": {
+        "react-cra": {
+          "DOMAIN": "http://localhost:3000"
+        }
+      }
     },
     {
       "name": "prebuilt-checkout-page",
@@ -27,7 +32,15 @@
         "java",
         "go",
         "dotnet"
-      ]
+      ],
+      "clientEnvOverrides": {
+        "react-cra": {
+          "DOMAIN": "http://localhost:3000"
+        },
+        "vue-cva": {
+          "DOMAIN": "http://localhost:3000"
+        }
+      }
     },
     {
       "name": "custom-payment-flow",
@@ -41,7 +54,12 @@
         "go",
         "dotnet",
         "node-typescript"
-      ]
+      ],
+      "clientEnvOverrides": {
+        "react-cra": {
+          "DOMAIN": "http://localhost:3000"
+        }
+      }
     },
     {
       "name": "elements-with-checkout-sessions",
@@ -54,7 +72,12 @@
         "java",
         "go",
         "dotnet"
-      ]
+      ],
+      "clientEnvOverrides": {
+        "react-cra": {
+          "DOMAIN": "http://localhost:3000"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `clientEnvOverrides` to all four integrations in `.cli.json` so that React (`react-cra`) and Vue (`vue-cva`) clients get `DOMAIN=http://localhost:3000` instead of the default `http://localhost:4242`
- Fixes broken `return_url`/`success_url` redirects when using `stripe samples create` with these clients, since their dev servers run on port 3000, not 4242. This improves the UX since they now don't have to configure any env variables and only have to start the servers. 

## Dependency
Requires CLI-side support for the `clientEnvOverrides` field in `stripe-cli`. Until that lands, this field is ignored by the CLI. This [PR](https://github.com/stripe/stripe-cli/pull/1561) was merged already, but we need the following to test:
  1. Owner of stripe/stripe-cli pushes a new tag that triggers the release workflow automatically
  2. Users update their CLI (brew upgrade stripe/stripe-cli/stripe or similar)

## Test plan
- [ ] After CLI support merges: `stripe samples create accept-a-payment` → pick any integration → `react-cra` → verify `server/.env` has `DOMAIN=http://localhost:3000`
- [ ] Same flow with `html` client → verify `DOMAIN=http://localhost:4242` (unchanged)
- [ ] `prebuilt-checkout-page` → `vue-cva` → verify `DOMAIN=http://localhost:3000`