### PR TITLE
Revamp README to recommend Elements with Checkout Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository includes four sample integrations built on two different APIs.
 
 ### Checkout Sessions API — Recommended
 
-Stripe recommends the Checkout Sessions API for most integrations. It requires less code than the Payment Intents API and includes built-in support for tax, recurring payments, localization, and automatic payment methods.
+Stripe recommends the Checkout Sessions API for most integrations. It requires less code than the Payment Intents API and includes built-in support for tax, discounts, shipping, adaptive pricing, recurring payments, localization, and automatic payment methods.
 
 #### [Elements with Checkout Sessions](./elements-with-checkout-sessions) — Custom form
 
@@ -24,7 +24,7 @@ Create a Checkout Session on your server, then render the Payment Element on you
 - **Customers stay on your site**, with a redirect after payment completion.
 - **Small refactor** to collect recurring payments.
 - **Built-in** input validation and error handling.
-- **Localized** in 25+ languages.
+- **Localized** in 50+ languages.
 - **Automate** sales tax, VAT, and GST calculation with one line of code.
 
 Servers: Node, Python, Ruby, PHP, Java, Go, .NET · Clients: HTML, React
@@ -42,7 +42,7 @@ Redirect customers to a Stripe-hosted payment page. The simplest integration wit
 - **Customers redirect** to a Stripe-hosted page, then return to your site.
 - **Small refactor** to collect recurring payments.
 - **Built-in** input validation and error handling.
-- **Localized** in 25+ languages.
+- **Localized** in 50+ languages.
 - **Automate** sales tax, VAT, and GST calculation with one line of code.
 
 Servers: Node, Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Vue
@@ -66,7 +66,7 @@ Render the Payment Element on your site using the Payment Intents API directly. 
 - **Customers stay on your site**, but payment completion may trigger a redirect.
 - **Large refactor** to collect recurring payments.
 - **Built-in** input validation; you must implement error handling.
-- **Localized** in 25+ languages.
+- **Localized** in 50+ languages.
 - Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom).
 
 Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Vue
@@ -103,6 +103,7 @@ Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · 
 | Customer experience | Stays on your site | Redirects to Stripe | Stays on your site | Stays on your site |
 | Recurring payments | Small refactor | Small refactor | Large refactor | Large refactor |
 | Tax calculation | Built-in | Built-in | Tax API | Tax API |
+| Adaptive pricing | Built-in | Built-in | Not available | Not available |
 | Payment methods | Automatic | Automatic | Automatic | Manual per method |
 
 ### Payment method support

--- a/README.md
+++ b/README.md
@@ -3,15 +3,19 @@
 _Explore different ways to accept payments on the web with Stripe._
 
 > [!TIP]
-> **Starting a new integration?** Stripe recommends [Elements with Checkout Sessions](./elements-with-checkout-sessions) — it combines the Checkout Sessions API with the Payment Element for the best balance of simplicity and customization. [Read the docs →](https://docs.stripe.com/payments/quickstart-checkout-sessions)
+> **Starting a new integration?** Stripe recommends building on the [Checkout Sessions API](https://docs.stripe.com/payments/checkout) — choose between a [Stripe-hosted page](./prebuilt-checkout-page) for simplicity or [Elements with Checkout Sessions](./elements-with-checkout-sessions) for full design control.
 
 ## Choose your integration
 
-This repository includes four sample integrations, ordered from Stripe's recommended starting point to maximum control.
+This repository includes four sample integrations built on two different APIs.
 
-### [Elements with Checkout Sessions](./elements-with-checkout-sessions) — Recommended
+### Checkout Sessions API — Recommended
 
-Create a Checkout Session on your server, then render the Payment Element on your site using the Checkout Sessions API with `ui_mode: 'elements'`.
+Stripe recommends the Checkout Sessions API for most integrations. It requires less code than the Payment Intents API and includes built-in support for tax, recurring payments, localization, and automatic payment methods.
+
+#### [Elements with Checkout Sessions](./elements-with-checkout-sessions) — Custom form
+
+Create a Checkout Session on your server, then render the Payment Element on your site using `ui_mode: 'elements'`. Full design control while Stripe handles the payment logic.
 
 - **Moderate complexity.** A few API calls on your server, a few lines of Stripe.js on your client.
 - **Customize** components with the [Appearance API](https://stripe.com/docs/stripe-js/appearance-api).
@@ -27,9 +31,7 @@ Servers: Node, Python, Ruby, PHP, Java, Go, .NET · Clients: HTML, React
 
 [Sample code](./elements-with-checkout-sessions) | [Docs](https://docs.stripe.com/payments/quickstart-checkout-sessions)
 
----
-
-### [Prebuilt Checkout page](./prebuilt-checkout-page) — Stripe-hosted
+#### [Prebuilt Checkout page](./prebuilt-checkout-page) — Stripe-hosted
 
 Redirect customers to a Stripe-hosted payment page. The simplest integration with the least code.
 
@@ -49,9 +51,13 @@ Servers: Node, Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, Reac
 
 ---
 
-### [Payment Element](./payment-element) — Direct API
+### Payment Intents API — Direct API
 
-Render the Payment Element on your site using the Payment Intents API directly. Similar UI to Elements with Checkout Sessions but requires more server-side code.
+The Payment Intents API gives you direct control over the payment lifecycle. It requires more server-side code and doesn't include built-in tax or easy recurring payment support. Use this when you need capabilities beyond what Checkout Sessions provides.
+
+#### [Payment Element](./payment-element) — Prebuilt UI
+
+Render the Payment Element on your site using the Payment Intents API directly. Similar UI to Elements with Checkout Sessions but you manage the payment lifecycle yourself.
 
 - **Moderate complexity.** More server-side payment lifecycle management.
 - **Customize** components with the [Appearance API](https://stripe.com/docs/stripe-js/appearance-api).
@@ -67,9 +73,7 @@ Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · 
 
 [Sample code](./payment-element) | [Docs](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements)
 
----
-
-### [Custom payment flow](./custom-payment-flow) — Advanced
+#### [Custom payment flow](./custom-payment-flow) — Advanced
 
 Build a fully custom checkout using individual Stripe Elements and the Payment Intents API. Maximum control over every detail.
 
@@ -91,8 +95,9 @@ Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · 
 
 ## At a glance
 
-| | Elements with Checkout Sessions | Prebuilt Checkout page | Payment Element | Custom payment flow |
+| | Checkout Sessions API | | Payment Intents API | |
 |---|---|---|---|---|
+| | Elements with Checkout Sessions | Prebuilt Checkout page | Payment Element | Custom payment flow |
 | Complexity | Moderate | Low | Moderate | High |
 | Customization | Appearance API | Logo, images, colors | Appearance API | Full CSS |
 | Customer experience | Stays on your site | Redirects to Stripe | Stays on your site | Stays on your site |
@@ -142,10 +147,13 @@ stripe samples create accept-a-payment
 
 You can also clone the repository directly. See the individual READMEs for setup instructions:
 
-- [**Elements with Checkout Sessions**](./elements-with-checkout-sessions/README.md) — start here
-- [Prebuilt Checkout page](./prebuilt-checkout-page/README.md)
-- [Payment Element](./payment-element/README.md)
-- [Custom payment flow](./custom-payment-flow/README.md)
+**Checkout Sessions API** (recommended):
+- [Elements with Checkout Sessions](./elements-with-checkout-sessions/README.md) — custom form on your site
+- [Prebuilt Checkout page](./prebuilt-checkout-page/README.md) — Stripe-hosted page
+
+**Payment Intents API:**
+- [Payment Element](./payment-element/README.md) — prebuilt UI, direct API
+- [Custom payment flow](./custom-payment-flow/README.md) — fully custom UI
 
 ## Testing
 
@@ -175,7 +183,7 @@ See [TESTING.md](./TESTING.md) for running tests inside Dev Containers.
 
 Q: **Which integration should I choose?**
 
-A: For most new projects, start with [Elements with Checkout Sessions](./elements-with-checkout-sessions). It gives you an embedded payment form with minimal server-side code, built-in tax calculation, and easy recurring payment support. Choose [Prebuilt Checkout page](./prebuilt-checkout-page) if you want a fully hosted page with zero front-end work. Choose [Custom payment flow](./custom-payment-flow) only if you need pixel-level control over every UI component.
+A: Start with the Checkout Sessions API — it handles tax, recurring payments, and localization with less code. Choose [Elements with Checkout Sessions](./elements-with-checkout-sessions) if you want a custom payment form on your site, or [Prebuilt Checkout page](./prebuilt-checkout-page) if you want a Stripe-hosted page with zero front-end work. The [Payment Element](./payment-element) and [Custom payment flow](./custom-payment-flow) use the Payment Intents API directly, which gives you more control but requires significantly more code.
 
 Q: **Why did you pick these frameworks?**
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,138 @@
 # Accept a payment
 
-_Learn how to securely accept payments online._
+_Explore different ways to accept payments on the web with Stripe._
 
-This repository includes examples of 4 types of integration.
+> [!TIP]
+> **Starting a new integration?** Stripe recommends [Elements with Checkout Sessions](./elements-with-checkout-sessions) — it combines the Checkout Sessions API with the Payment Element for the best balance of simplicity and customization. [Read the docs →](https://docs.stripe.com/payments/quickstart-checkout-sessions)
 
-|[Prebuilt Checkout page](./prebuilt-checkout-page) ([docs](https://stripe.com/docs/payments/accept-a-payment?ui=checkout))| [Payment Element](./payment-element) ([docs](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements)) | [Custom payment flow](./custom-payment-flow) ([docs](https://stripe.com/docs/payments/accept-card-payments?platform=web&ui=elements)) | [Elements with Checkout Sessions](./elements-with-checkout-sessions) ([docs](https://docs.stripe.com/payments/quickstart-checkout-sessions)) |
-|---|---|---|---|
-| Lower complexity. | Moderate complexity. | Higher complexity. | Moderate complexity. |
-| Customize logo, images, and colors. | Customize components with [Appearance API](https://stripe.com/docs/stripe-js/appearance-api). | Customize all components with CSS. | Customize components with [Appearance API](https://stripe.com/docs/stripe-js/appearance-api). |
-| Add payment method types with a single line change. | Add payment methods with a single line change. | Implement each payment method type as a custom integration. | Add payment methods with a single line change. |
-| Built-in support for Apple Pay, and Google Pay. | Built-in support for Apple Pay and Google Pay. | Integrate Apple Pay and Google Pay with extra code.| Built-in support for Apple Pay and Google Pay. |
-| Redirect to Stripe hosted page. | Customers stay on your site, but payment completion triggers a redirect. |Customers stay on your site. | Customers stay on your site, but payment completion triggers a redirect. |
-| Small refactor to collect recurring payments. | Large refactor to collect recurring payments. | Large refactor to collect recurring payments. | Small refactor to collect recurring payments. |
-| Input validation and error handling built in. | Input validation built-in but you must implement error handling. | Implement your own input validation and error handling. | Input validation built-in but you must implement error handling. |
-| Localized in 25+ languages. | Localized in 25+ languages. |Implement your own localization. | Localized in 25+ languages. |
-| Automate calculation and collection of sales tax, VAT and GST with one line of code. | Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom) | Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom) | Automate calculation and collection of sales tax, VAT and GST with one line of code. |
+## Choose your integration
 
+This repository includes four sample integrations, ordered from Stripe's recommended starting point to maximum control.
 
-### Payment Method Type Support
+### [Elements with Checkout Sessions](./elements-with-checkout-sessions) — Recommended
 
-|Payment Method Type | [Prebuilt Checkout page](./prebuilt-checkout-page) ([docs](https://stripe.com/docs/payments/accept-a-payment?ui=checkout))| [Payment Element](./payment-element) ([docs](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements)) | [Custom payment flow](./custom-payment-flow) ([docs](https://stripe.com/docs/payments/accept-card-payments?platform=web&ui=elements)) | [Elements with Checkout Sessions](./elements-with-checkout-sessions) ([docs](https://docs.stripe.com/payments/quickstart-checkout-sessions)) |
+Create a Checkout Session on your server, then render the Payment Element on your site using the Checkout Sessions API with `ui_mode: 'elements'`.
+
+- **Moderate complexity.** A few API calls on your server, a few lines of Stripe.js on your client.
+- **Customize** components with the [Appearance API](https://stripe.com/docs/stripe-js/appearance-api).
+- **Payment methods added automatically** — no code changes needed for new methods.
+- **Built-in** Apple Pay and Google Pay support.
+- **Customers stay on your site**, with a redirect after payment completion.
+- **Small refactor** to collect recurring payments.
+- **Built-in** input validation and error handling.
+- **Localized** in 25+ languages.
+- **Automate** sales tax, VAT, and GST calculation with one line of code.
+
+Servers: Node, Python, Ruby, PHP, Java, Go, .NET · Clients: HTML, React
+
+[Sample code](./elements-with-checkout-sessions) | [Docs](https://docs.stripe.com/payments/quickstart-checkout-sessions)
+
+---
+
+### [Prebuilt Checkout page](./prebuilt-checkout-page) — Stripe-hosted
+
+Redirect customers to a Stripe-hosted payment page. The simplest integration with the least code.
+
+- **Low complexity.** Create a Checkout Session and redirect — that's it.
+- **Customize** logo, images, and colors.
+- **Payment methods added automatically** with a single line change.
+- **Built-in** Apple Pay and Google Pay support.
+- **Customers redirect** to a Stripe-hosted page, then return to your site.
+- **Small refactor** to collect recurring payments.
+- **Built-in** input validation and error handling.
+- **Localized** in 25+ languages.
+- **Automate** sales tax, VAT, and GST calculation with one line of code.
+
+Servers: Node, Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Vue
+
+[Sample code](./prebuilt-checkout-page) | [Docs](https://stripe.com/docs/payments/accept-a-payment?ui=checkout)
+
+---
+
+### [Payment Element](./payment-element) — Direct API
+
+Render the Payment Element on your site using the Payment Intents API directly. Similar UI to Elements with Checkout Sessions but requires more server-side code.
+
+- **Moderate complexity.** More server-side payment lifecycle management.
+- **Customize** components with the [Appearance API](https://stripe.com/docs/stripe-js/appearance-api).
+- **Payment methods added automatically** with a single line change.
+- **Built-in** Apple Pay and Google Pay support.
+- **Customers stay on your site**, but payment completion may trigger a redirect.
+- **Large refactor** to collect recurring payments.
+- **Built-in** input validation; you must implement error handling.
+- **Localized** in 25+ languages.
+- Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom).
+
+Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Vue
+
+[Sample code](./payment-element) | [Docs](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements)
+
+---
+
+### [Custom payment flow](./custom-payment-flow) — Advanced
+
+Build a fully custom checkout using individual Stripe Elements and the Payment Intents API. Maximum control over every detail.
+
+- **High complexity.** You manage the full payment lifecycle and UI.
+- **Customize** all components with CSS.
+- **Implement each payment method** as a separate integration.
+- **Integrate** Apple Pay and Google Pay with extra code.
+- **Customers stay on your site** throughout the entire flow.
+- **Large refactor** to collect recurring payments.
+- **Implement your own** input validation and error handling.
+- **Implement your own** localization.
+- Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom).
+
+Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Android (Kotlin), iOS (SwiftUI), React Native (Expo)
+
+[Sample code](./custom-payment-flow) | [Docs](https://stripe.com/docs/payments/accept-card-payments?platform=web&ui=elements)
+
+---
+
+## At a glance
+
+| | Elements with Checkout Sessions | Prebuilt Checkout page | Payment Element | Custom payment flow |
 |---|---|---|---|---|
-|ACH Credit Transfer|  |  | | |
-|ACH Debit| ✅ | ✅ | ✅ | ✅ |
-|Afterpay/Clearpay| ✅ | ✅ | ✅ | ✅ |
-|Alipay| ✅ | ✅ | ✅ | ✅ |
-|Apple Pay| ✅ | ✅ | ✅ | ✅ |
-|Bacs Direct Debit| ✅ |  |  | ✅ |
-|Bancontact| ✅ | ✅ | ✅ | ✅ |
-|BECS Direct Debit| ✅ | ✅ | ✅ | ✅ |
-|Boleto| ✅ | ✅ | ✅ | ✅ |
-|Cards| ✅ | ✅ | ✅ | ✅ |
-|EPS| ✅ | ✅ | ✅ | ✅ |
-|FPX| ✅ | ✅ | ✅ | ✅ |
-|giropay| ✅ | ✅ | ✅ | ✅ |
-|Google Pay| ✅ | ✅ | ✅ | ✅ |
-|GrabPay| ✅ | ✅ | ✅ | ✅ |
-|iDEAL| ✅ | ✅ | ✅ | ✅ |
-|Klarna| ✅ | ✅ | ✅ | ✅ |
-|Link| ✅ | ✅ |  | ✅ |
-|Multibanco| ✅ | ✅ |  | ✅ |
-|OXXO| ✅ | ✅ | ✅ | ✅ |
-|PayPal| ✅ | ✅ | ✅ | ✅ |
-|Przelewy24 (P24)| ✅ | ✅ | ✅ | ✅ |
-|SEPA Direct Debit| ✅ | ✅ | ✅ | ✅ |
-|Sofort| ✅ | ✅ | ✅ | ✅ |
-|WeChat Pay| ✅ | ✅ | ✅ | ✅ |
+| Complexity | Moderate | Low | Moderate | High |
+| Customization | Appearance API | Logo, images, colors | Appearance API | Full CSS |
+| Customer experience | Stays on your site | Redirects to Stripe | Stays on your site | Stays on your site |
+| Recurring payments | Small refactor | Small refactor | Large refactor | Large refactor |
+| Tax calculation | Built-in | Built-in | Tax API | Tax API |
+| Payment methods | Automatic | Automatic | Automatic | Manual per method |
 
+### Payment method support
 
-## Installation
+| Payment method | Elements with Checkout Sessions | Prebuilt Checkout page | Payment Element | Custom payment flow |
+|---|---|---|---|---|
+| ACH Debit | ✅ | ✅ | ✅ | ✅ |
+| Affirm | ✅ | ✅ | ✅ | |
+| Afterpay / Clearpay | ✅ | ✅ | ✅ | ✅ |
+| Alipay | ✅ | ✅ | ✅ | ✅ |
+| Amazon Pay | ✅ | ✅ | ✅ | |
+| Apple Pay | ✅ | ✅ | ✅ | ✅ |
+| Bacs Direct Debit | ✅ | ✅ | | |
+| Bancontact | ✅ | ✅ | ✅ | ✅ |
+| BECS Direct Debit | ✅ | ✅ | ✅ | ✅ |
+| Boleto | ✅ | ✅ | ✅ | ✅ |
+| Cards | ✅ | ✅ | ✅ | ✅ |
+| Cash App Pay | ✅ | ✅ | ✅ | |
+| EPS | ✅ | ✅ | ✅ | ✅ |
+| FPX | ✅ | ✅ | ✅ | ✅ |
+| Google Pay | ✅ | ✅ | ✅ | ✅ |
+| GrabPay | ✅ | ✅ | ✅ | ✅ |
+| iDEAL | ✅ | ✅ | ✅ | ✅ |
+| Klarna | ✅ | ✅ | ✅ | ✅ |
+| Link | ✅ | ✅ | ✅ | |
+| Multibanco | ✅ | ✅ | ✅ | |
+| OXXO | ✅ | ✅ | ✅ | ✅ |
+| PayPal | ✅ | ✅ | ✅ | ✅ |
+| Przelewy24 (P24) | ✅ | ✅ | ✅ | ✅ |
+| Revolut Pay | ✅ | ✅ | ✅ | |
+| SEPA Direct Debit | ✅ | ✅ | ✅ | ✅ |
+| WeChat Pay | ✅ | ✅ | ✅ | ✅ |
+| Zip | ✅ | ✅ | ✅ | |
+
+## Quick start
 
 The recommended way to use this Stripe Sample is with the [Stripe CLI](https://stripe.com/docs/stripe-cli#install):
 
@@ -56,26 +140,46 @@ The recommended way to use this Stripe Sample is with the [Stripe CLI](https://s
 stripe samples create accept-a-payment
 ```
 
-You can also clone the repository, but there is a bit more manual setup work to
-configure the `.env` environment variable file in the server directory.
+You can also clone the repository directly. See the individual READMEs for setup instructions:
 
-You'll find more detailed instructions for each integration type in the
-relevant READMEs:
-
+- [**Elements with Checkout Sessions**](./elements-with-checkout-sessions/README.md) — start here
 - [Prebuilt Checkout page](./prebuilt-checkout-page/README.md)
 - [Payment Element](./payment-element/README.md)
 - [Custom payment flow](./custom-payment-flow/README.md)
-- [Elements with Checkout Sessions](./elements-with-checkout-sessions/README.md)
 
----
+## Testing
+
+See [TESTING.md](./TESTING.md).
+
+<details>
+<summary><strong>Dev Containers and Codespaces</strong></summary>
+
+We provide [Dev Container](https://containers.dev/) configurations for most of the sample apps for web. In Visual Studio Code, use `Reopen in Containers` from the Command Palette and choose a sample from the options.
+
+You can also try these samples without installing Docker by using [GitHub Codespaces](https://github.com/features/codespaces). Click "New with options..." and choose a sample from the Dev container configuration select box. **Note: you will be charged for GitHub Codespaces usage.**
+
+![](https://github.com/stripe-samples/accept-a-payment/assets/43346/9db4688c-a71d-4624-80f1-4b79c5cae44d)
+
+After launching, export the required environment variables and start the server:
+
+```sh
+export STRIPE_PUBLISHABLE_KEY=pk_test_...
+export STRIPE_SECRET_KEY=sk_test_...
+```
+
+See [TESTING.md](./TESTING.md) for running tests inside Dev Containers.
+
+</details>
+
 ## FAQ
 
-Q: Why did you pick these frameworks?
+Q: **Which integration should I choose?**
 
-A: We chose the most minimal framework to convey the key Stripe calls and
-concepts you need to understand. These demos are meant as an educational tool
-that helps you roadmap how to integrate Stripe within your own system
-independent of the framework.
+A: For most new projects, start with [Elements with Checkout Sessions](./elements-with-checkout-sessions). It gives you an embedded payment form with minimal server-side code, built-in tax calculation, and easy recurring payment support. Choose [Prebuilt Checkout page](./prebuilt-checkout-page) if you want a fully hosted page with zero front-end work. Choose [Custom payment flow](./custom-payment-flow) only if you need pixel-level control over every UI component.
+
+Q: **Why did you pick these frameworks?**
+
+A: We chose the most minimal framework to convey the key Stripe calls and concepts you need to understand. These demos are meant as an educational tool that helps you roadmap how to integrate Stripe within your own system independent of the framework.
 
 ## Get support
 
@@ -83,57 +187,10 @@ If you found a bug or want to suggest a new [feature/use case/sample], please [f
 
 If you have questions, comments, or need help with code, we're here to help:
 - on [Discord](https://stripe.com/go/developer-chat)
-- on Twitter at [@StripeDev](https://twitter.com/StripeDev)
+- on X at [@StripeDev](https://x.com/StripeDev)
 - on Stack Overflow at the [stripe-payments](https://stackoverflow.com/tags/stripe-payments/info) tag
 
 Sign up to [stay updated with developer news](https://go.stripe.global/dev-digest).
-
-
-## Testing
-
-See [TESTING.md](./TESTING.md).
-
-## Running samples with Dev Containers or Codespaces
-
-We provide [Dev Container](https://containers.dev/) configurations for most of the sample apps for web. For the Visual Studio Code example, by hitting `Reopen in Containers` in the Command Pallete and choosing a sample from the options prompted, dedicated Docker containers for the sample will be automatically created.
-
-You can also try these samples even without installing Docker on your machine by using [GitHub Codespaces](https://github.com/features/codespaces). A sample app codespace can be created by clicking "New with options..." below and choosing a sample app from the Dev container configuration select box. **Note that in this case, you would be charged for usage of GitHub Codespaces.**
-
-![](https://github.com/stripe-samples/accept-a-payment/assets/43346/9db4688c-a71d-4624-80f1-4b79c5cae44d)
-
-### Running server app samples
-
-After launching the environment, a couple of setup steps would be needed to launch the web app. For the NodeJS (`custom-payment-flow-server-node`) example:
-
-1. Export the required environment variables
-    1. `export STRIPE_PUBLISHABLE_KEY=XXXX`
-    2. `export STRIPE_SECRET_KEY=XXXX`
-    3. `export PRICE=XXXX`
-2. Install the dependencies and run the web server. For NodeJS example, `npm install && npm run start`
-
-You can also run some tests for the server app by the following steps. This example is a little hacky as we need to use SSH to run a test command in another container (`runner`).
-
-1. Run `ssh-keygen` and `chmod 600 ~/.ssh/*`
-2. Login to the test runner service with `ssh runner`
-3. Move to the working dir with `cd /work`
-4. Export the required environment variables
-    1. `export $(cat .devcontainer/.env | xargs)`
-    2. `export STRIPE_PUBLISHABLE_KEY=XXXX`
-    3. `export STRIPE_SECRET_KEY=XXXX`
-    4. `export PRICE=XXXX`
-5. Run tests like `bundle exec rspec spec/custom_payment_flow_server_spec.rb `
-
-### Running client app samples
-
-After launching the environment, a couple of setup steps would be needed to launch the app. For the Create React App (`custom-payment-flow-client-react-cra`) example:
-
-1. Export the required environment variables
-    1. `export STRIPE_PUBLISHABLE_KEY=XXXX`
-    2. `export STRIPE_SECRET_KEY=XXXX`
-    3. `export PRICE=XXXX`
-2. Install the dependencies and run the node web server by running `cd ../../server/node && npm install && npm run start`
-3. In another terminal, install the dependencies and run the client app by running `npm install && npm start`
-  * :memo: You might want to set `server.hmr.port` to `443` in `vite.config.js` ([related issue](https://github.com/vitejs/vite/issues/4259))
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 _Explore different ways to accept payments on the web with Stripe._
 
 > [!TIP]
-> **Starting a new integration?** Stripe recommends building on the [Checkout Sessions API](https://docs.stripe.com/payments/checkout) — choose between a [Stripe-hosted page](./prebuilt-checkout-page) for simplicity or [Elements with Checkout Sessions](./elements-with-checkout-sessions) for full design control.
+> **Starting a new integration?** Stripe recommends building on the [Checkout Sessions API](https://docs.stripe.com/payments/checkout) — choose a [Stripe-hosted page](./prebuilt-checkout-page) for simplicity or [Elements with Checkout Sessions](./elements-with-checkout-sessions) for full design control.
 
 ## Choose your integration
 
@@ -12,24 +12,6 @@ This repository includes four sample integrations built on two different APIs.
 ### Checkout Sessions API — Recommended
 
 Stripe recommends the Checkout Sessions API for most integrations. It requires less code than the Payment Intents API and includes built-in support for tax, discounts, shipping, adaptive pricing, recurring payments, localization, and automatic payment methods.
-
-#### [Elements with Checkout Sessions](./elements-with-checkout-sessions) — Custom form
-
-Create a Checkout Session on your server, then render the Payment Element on your site using `ui_mode: 'elements'`. Full design control while Stripe handles the payment logic.
-
-- **Moderate complexity.** A few API calls on your server, a few lines of Stripe.js on your client.
-- **Customize** components with the [Appearance API](https://stripe.com/docs/stripe-js/appearance-api).
-- **Payment methods added automatically** — no code changes needed for new methods.
-- **Built-in** Apple Pay and Google Pay support.
-- **Customers stay on your site**, with a redirect after payment completion.
-- **Small refactor** to collect recurring payments.
-- **Built-in** input validation and error handling.
-- **Localized** in 50+ languages.
-- **Automate** sales tax, VAT, and GST calculation with one line of code.
-
-Servers: Node, Python, Ruby, PHP, Java, Go, .NET · Clients: HTML, React
-
-[Sample code](./elements-with-checkout-sessions) | [Docs](https://docs.stripe.com/payments/quickstart-checkout-sessions)
 
 #### [Prebuilt Checkout page](./prebuilt-checkout-page) — Stripe-hosted
 
@@ -48,6 +30,24 @@ Redirect customers to a Stripe-hosted payment page. The simplest integration wit
 Servers: Node, Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Vue
 
 [Sample code](./prebuilt-checkout-page) | [Docs](https://stripe.com/docs/payments/accept-a-payment?ui=checkout)
+
+#### [Elements with Checkout Sessions](./elements-with-checkout-sessions) — Custom form
+
+Create a Checkout Session on your server, then render the Payment Element on your site using `ui_mode: 'elements'`. Full design control while Stripe handles the payment logic.
+
+- **Moderate complexity.** A few API calls on your server, a few lines of Stripe.js on your client.
+- **Customize** components with the [Appearance API](https://stripe.com/docs/stripe-js/appearance-api).
+- **Payment methods added automatically** — no code changes needed for new methods.
+- **Built-in** Apple Pay and Google Pay support.
+- **Customers stay on your site**, with a redirect after payment completion.
+- **Small refactor** to collect recurring payments.
+- **Built-in** input validation and error handling.
+- **Localized** in 50+ languages.
+- **Automate** sales tax, VAT, and GST calculation with one line of code.
+
+Servers: Node, Python, Ruby, PHP, Java, Go, .NET · Clients: HTML, React
+
+[Sample code](./elements-with-checkout-sessions) | [Docs](https://docs.stripe.com/payments/quickstart-checkout-sessions)
 
 ---
 
@@ -97,10 +97,10 @@ Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · 
 
 | | Checkout Sessions API | | Payment Intents API | |
 |---|---|---|---|---|
-| | Elements with Checkout Sessions | Prebuilt Checkout page | Payment Element | Custom payment flow |
-| Complexity | Moderate | Low | Moderate | High |
-| Customization | Appearance API | Logo, images, colors | Appearance API | Full CSS |
-| Customer experience | Stays on your site | Redirects to Stripe | Stays on your site | Stays on your site |
+| | Prebuilt Checkout page | Elements with Checkout Sessions | Payment Element | Custom payment flow |
+| Complexity | Low | Moderate | Moderate | High |
+| Customization | Logo, images, colors | Appearance API | Appearance API | Full CSS |
+| Customer experience | Redirects to Stripe | Stays on your site | Stays on your site | Stays on your site |
 | Recurring payments | Small refactor | Small refactor | Large refactor | Large refactor |
 | Tax calculation | Built-in | Built-in | Tax API | Tax API |
 | Adaptive pricing | Built-in | Built-in | Not available | Not available |
@@ -108,7 +108,7 @@ Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · 
 
 ### Payment method support
 
-| Payment method | Elements with Checkout Sessions | Prebuilt Checkout page | Payment Element | Custom payment flow |
+| Payment method | Prebuilt Checkout page | Elements with Checkout Sessions | Payment Element | Custom payment flow |
 |---|---|---|---|---|
 | ACH Debit | ✅ | ✅ | ✅ | ✅ |
 | Affirm | ✅ | ✅ | ✅ | |
@@ -149,8 +149,8 @@ stripe samples create accept-a-payment
 You can also clone the repository directly. See the individual READMEs for setup instructions:
 
 **Checkout Sessions API** (recommended):
-- [Elements with Checkout Sessions](./elements-with-checkout-sessions/README.md) — custom form on your site
 - [Prebuilt Checkout page](./prebuilt-checkout-page/README.md) — Stripe-hosted page
+- [Elements with Checkout Sessions](./elements-with-checkout-sessions/README.md) — custom form on your site
 
 **Payment Intents API:**
 - [Payment Element](./payment-element/README.md) — prebuilt UI, direct API
@@ -184,7 +184,7 @@ See [TESTING.md](./TESTING.md) for running tests inside Dev Containers.
 
 Q: **Which integration should I choose?**
 
-A: Start with the Checkout Sessions API — it handles tax, recurring payments, and localization with less code. Choose [Elements with Checkout Sessions](./elements-with-checkout-sessions) if you want a custom payment form on your site, or [Prebuilt Checkout page](./prebuilt-checkout-page) if you want a Stripe-hosted page with zero front-end work. The [Payment Element](./payment-element) and [Custom payment flow](./custom-payment-flow) use the Payment Intents API directly, which gives you more control but requires significantly more code.
+A: Start with the Checkout Sessions API — it handles tax, recurring payments, and localization with less code. Choose [Prebuilt Checkout page](./prebuilt-checkout-page) for a Stripe-hosted page with zero front-end work, or [Elements with Checkout Sessions](./elements-with-checkout-sessions) if you want a custom payment form on your site. The [Payment Element](./payment-element) and [Custom payment flow](./custom-payment-flow) use the Payment Intents API directly, which gives you more control but requires significantly more code.
 
 Q: **Why did you pick these frameworks?**
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Redirect customers to a Stripe-hosted payment page. The simplest integration wit
 - **Localized** in 50+ languages.
 - **Automate** sales tax, VAT, and GST calculation with one line of code.
 
-Servers: Node, Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Vue
-
 [Sample code](./prebuilt-checkout-page) | [Docs](https://stripe.com/docs/payments/accept-a-payment?ui=checkout)
 
 #### [Elements with Checkout Sessions](./elements-with-checkout-sessions) — Custom form
@@ -44,8 +42,6 @@ Create a Checkout Session on your server, then render the Payment Element on you
 - **Built-in** input validation and error handling.
 - **Localized** in 50+ languages.
 - **Automate** sales tax, VAT, and GST calculation with one line of code.
-
-Servers: Node, Python, Ruby, PHP, Java, Go, .NET · Clients: HTML, React
 
 [Sample code](./elements-with-checkout-sessions) | [Docs](https://docs.stripe.com/payments/quickstart-checkout-sessions)
 
@@ -69,8 +65,6 @@ Render the Payment Element on your site using the Payment Intents API directly. 
 - **Localized** in 50+ languages.
 - Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom).
 
-Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Vue
-
 [Sample code](./payment-element) | [Docs](https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=elements)
 
 #### [Custom payment flow](./custom-payment-flow) — Advanced
@@ -86,8 +80,6 @@ Build a fully custom checkout using individual Stripe Elements and the Payment I
 - **Implement your own** input validation and error handling.
 - **Implement your own** localization.
 - Calculate tax using the [Tax API](https://stripe.com/docs/tax/custom).
-
-Servers: Node, Node (TypeScript), Python, Ruby, PHP, Java, Go, .NET, Next.js · Clients: HTML, React, Android (Kotlin), iOS (SwiftUI), React Native (Expo)
 
 [Sample code](./custom-payment-flow) | [Docs](https://stripe.com/docs/payments/accept-card-payments?platform=web&ui=elements)
 


### PR DESCRIPTION
## Summary

- Restructures the 6-year-old README to reflect Stripe's current recommendation of Checkout Sessions API + Payment Element (Elements with Checkout Sessions)
- Replaces flat 4-column comparison table with a tiered vertical layout: Recommended → Stripe-hosted → Direct API → Advanced
- Updates payment method matrix: removes deprecated giropay/Sofort, adds Affirm, Amazon Pay, Cash App Pay, Revolut Pay, Zip
- Adds `[!TIP]` recommendation callout, "Which integration should I choose?" FAQ, and condensed "At a glance" table
- Collapses Dev Container instructions into `<details>` block to reduce noise

## Test plan

- [ ] Preview rendered README on GitHub to verify formatting, `[!TIP]` callout, `<details>` collapse, and table rendering
- [ ] Click-test all internal links (sample folders, TESTING.md)
- [ ] Click-test all external doc URLs
- [ ] Verify payment method matrix accuracy against Stripe docs
- [ ] Check mobile rendering of tables