### PR TITLE
Fix Stripe CLI compatibility for EwCS sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 _Explore different ways to accept payments on the web with Stripe._
 
 > [!TIP]
+> **Downloaded via `stripe samples create`?** Your server is in `./server/` and your client is in `./client/`. Run `stripe login`, then install dependencies and start the server (e.g. `cd server && npm install && npm start` for Node). It listens on http://localhost:4242.
+
+> [!TIP]
 > **Starting a new integration?** Stripe recommends building on the [Checkout Sessions API](https://docs.stripe.com/payments/checkout) — choose a [Stripe-hosted page](./prebuilt-checkout-page) for simplicity or [Elements with Checkout Sessions](./elements-with-checkout-sessions) for full design control.
 
 ## Choose your integration

--- a/elements-with-checkout-sessions/.env.example
+++ b/elements-with-checkout-sessions/.env.example
@@ -1,7 +1,9 @@
 STRIPE_PUBLISHABLE_KEY=<replace-with-your-publishable-key>
 STRIPE_SECRET_KEY=<replace-with-your-secret-key>
 STRIPE_WEBHOOK_SECRET=<replace-with-your-webhook-secret>
-STATIC_DIR=../../client/html
+# Path to static client files (auto-detected if not set).
+# Repo clone: ../../client/html  |  Stripe CLI: ../client
+# STATIC_DIR=../../client/html
 # For React/Vue clients, set to the dev server URL (e.g. http://localhost:3000)
 DOMAIN=http://localhost:4242
 PORT=4242

--- a/elements-with-checkout-sessions/.mise.toml
+++ b/elements-with-checkout-sessions/.mise.toml
@@ -1,8 +1,0 @@
-[tools]
-node = "24"
-python = "3.12"
-ruby = "3.3"
-go = "1.26"
-java = "17"
-dotnet = "9"
-"ubi:adwinying/php" = "8.2.19"

--- a/elements-with-checkout-sessions/README.md
+++ b/elements-with-checkout-sessions/README.md
@@ -30,7 +30,6 @@ the payment form.
 │   └── dotnet
 ├── testing
 │   └── manual-test.sh  # Run all 14 server×client combinations
-├── .mise.toml          # Tool versions (mise install)
 └── .env.example        # Root env template
 ```
 
@@ -45,7 +44,6 @@ the payment form.
   - **Java** >= 17 with Maven
   - **Go** >= 1.22
   - **.NET** >= 9.0
-- Or install all runtimes automatically with [mise](https://mise.jdx.dev): `mise install`
 
 ## Environment variables
 

--- a/elements-with-checkout-sessions/server/php/public/config.php
+++ b/elements-with-checkout-sessions/server/php/public/config.php
@@ -10,4 +10,4 @@ if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
 
 header('Content-Type: application/json');
 
-echo json_encode(array('publishableKey' => $_ENV['STRIPE_PUBLISHABLE_KEY']));
+echo json_encode(array('publishableKey' => $_ENV['STRIPE_PUBLISHABLE_KEY'] ?? getenv('STRIPE_PUBLISHABLE_KEY')));

--- a/elements-with-checkout-sessions/server/php/secrets.php
+++ b/elements-with-checkout-sessions/server/php/secrets.php
@@ -8,7 +8,7 @@ foreach ($_ENV as $key => $value) {
     putenv("$key=$value");
 }
 
-$stripeSecretKey = $_ENV['STRIPE_SECRET_KEY'];
+$stripeSecretKey = $_ENV['STRIPE_SECRET_KEY'] ?? getenv('STRIPE_SECRET_KEY');
 
 // For sample support and debugging, not required for production:
 \Stripe\Stripe::setAppInfo(

--- a/elements-with-checkout-sessions/testing/manual-test.sh
+++ b/elements-with-checkout-sessions/testing/manual-test.sh
@@ -10,6 +10,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SAMPLE_DIR="$SCRIPT_DIR/.."
 
+# Runtime versions
+NODE_V="24"
+PYTHON_V="3.12"
+RUBY_V="3.3"
+GO_V="1.26"
+JAVA_V="17"
+DOTNET_V="9"
+PHP_V="8.2.19"
+
 if ! command -v mise &>/dev/null; then
   echo "mise is required but not installed. Install it with:"
   echo "  curl https://mise.run | sh"
@@ -19,7 +28,7 @@ fi
 
 # Install all required language runtimes via mise
 echo "Installing runtimes via mise..."
-mise install node python ruby go java dotnet "ubi:adwinying/php"
+mise install node@$NODE_V python@$PYTHON_V ruby@$RUBY_V go@$GO_V java@$JAVA_V dotnet@$DOTNET_V "ubi:adwinying/php@$PHP_V"
 PIDS=()
 
 # Kill any leftover processes from a previous run
@@ -68,13 +77,13 @@ set +a
 
 # --- Install dependencies ---
 echo "Installing dependencies..."
-(cd "$SAMPLE_DIR/server/node" && npm install --silent) &
-(cd "$SAMPLE_DIR/server/ruby" && bundle install --quiet) &
-(cd "$SAMPLE_DIR/server/python" && pip install -q -r requirements.txt) &
-(cd "$SAMPLE_DIR/server/go" && go build -o /dev/null server.go) &
-(cd "$SAMPLE_DIR/server/java" && mvn -q compile) &
-(cd "$SAMPLE_DIR/server/php" && composer install --quiet) &
-(cd "$SAMPLE_DIR/client/react-cra" && npm install --silent) &
+(cd "$SAMPLE_DIR/server/node" && mise exec node@$NODE_V -- npm install --silent) &
+(cd "$SAMPLE_DIR/server/ruby" && mise exec ruby@$RUBY_V -- bundle install --quiet) &
+(cd "$SAMPLE_DIR/server/python" && mise exec python@$PYTHON_V -- pip install -q -r requirements.txt) &
+(cd "$SAMPLE_DIR/server/go" && mise exec go@$GO_V -- go build -o /dev/null server.go) &
+(cd "$SAMPLE_DIR/server/java" && mise exec java@$JAVA_V -- mvn -q compile) &
+(cd "$SAMPLE_DIR/server/php" && mise exec "ubi:adwinying/php@$PHP_V" -- composer install --quiet) &
+(cd "$SAMPLE_DIR/client/react-cra" && mise exec node@$NODE_V -- npm install --silent) &
 wait
 echo "Dependencies installed."
 echo ""
@@ -83,37 +92,37 @@ echo ""
 echo "Starting servers..."
 
 cd "$SAMPLE_DIR/server/node" && PORT=4242 \
-  node server.js >/dev/null 2>&1 &
+  mise exec node@$NODE_V -- node server.js >/dev/null 2>&1 &
 PIDS+=($!)
 cd "$SAMPLE_DIR"
 
 cd "$SAMPLE_DIR/server/ruby" && PORT=4243 \
-  ruby server.rb >/dev/null 2>&1 &
+  mise exec ruby@$RUBY_V -- ruby server.rb >/dev/null 2>&1 &
 PIDS+=($!)
 cd "$SAMPLE_DIR"
 
 cd "$SAMPLE_DIR/server/python" && PORT=4244 \
-  python3 server.py >/dev/null 2>&1 &
+  mise exec python@$PYTHON_V -- python3 server.py >/dev/null 2>&1 &
 PIDS+=($!)
 cd "$SAMPLE_DIR"
 
 cd "$SAMPLE_DIR/server/go" && PORT=4245 \
-  go run server.go >/dev/null 2>&1 &
+  mise exec go@$GO_V -- go run server.go >/dev/null 2>&1 &
 PIDS+=($!)
 cd "$SAMPLE_DIR"
 
 cd "$SAMPLE_DIR/server/java" && PORT=4246 \
-  mvn -q exec:java >/dev/null 2>&1 &
+  mise exec java@$JAVA_V -- mvn -q exec:java >/dev/null 2>&1 &
 PIDS+=($!)
 cd "$SAMPLE_DIR"
 
 cd "$SAMPLE_DIR/server/dotnet" && PORT=4247 \
-  dotnet run >/dev/null 2>&1 &
+  mise exec dotnet@$DOTNET_V -- dotnet run >/dev/null 2>&1 &
 PIDS+=($!)
 cd "$SAMPLE_DIR"
 
 cd "$SAMPLE_DIR/server/php" && PORT=4248 \
-  php -S localhost:4248 router.php >/dev/null 2>&1 &
+  mise exec "ubi:adwinying/php@$PHP_V" -- php -S localhost:4248 router.php >/dev/null 2>&1 &
 PIDS+=($!)
 cd "$SAMPLE_DIR"
 
@@ -136,7 +145,7 @@ for i in $(seq 0 6); do
   VITE_SERVER_URL="http://localhost:$((4242 + i))" \
   VITE_CACHE_DIR="/tmp/vite-cache-$((3000 + i))" \
   PORT=$((3000 + i)) \
-    npx --prefix "$REACT_DIR" vite --config "$REACT_DIR/vite.config.mjs" "$REACT_DIR" >/dev/null 2>&1 &
+    mise exec node@$NODE_V -- npx --prefix "$REACT_DIR" vite --config "$REACT_DIR/vite.config.mjs" "$REACT_DIR" >/dev/null 2>&1 &
   PIDS+=($!)
 done
 


### PR DESCRIPTION
## Summary

Fixes issues reported when using `stripe samples create` with the EwCS sample:

- **Remove `.mise.toml`** from sample root — it auto-activated and conflicted with users' own mise configs, causing "big errors". Runtime versions are now pinned inline in `manual-test.sh` using `mise exec <tool>@<version>`.
- **Fix PHP `$_ENV` fallback** — `$_ENV['STRIPE_SECRET_KEY']` fails on PHP 8.5 where `variables_order` lacks `E`. Added `?? getenv()` fallback.
- **Comment out `STATIC_DIR` in `.env.example`** — the hardcoded default `../../client/html` is correct for repo-clone users. CLI users get `STATIC_DIR=../client` auto-set. Commenting it out prevents confusion when someone copies `.env.example` in the CLI structure.
- **Add CLI tip to root README** — the root README is what CLI users see (the integration-specific README doesn't get copied). Added a one-liner explaining the flattened structure.

## Context

A teammate used `stripe samples create accept-a-payment` (PHP + HTML) without `stripe login` and hit:
1. mise.toml conflicts breaking their shell
2. PHP warnings from `$_ENV` on PHP 8.5
3. Confusion about `client/html` references (correct for repo clone, wrong for CLI output)
4. Root README mentioning Docker and multiple integrations irrelevant to their setup

## Test plan

- [ ] `cd elements-with-checkout-sessions/server/php && composer install && composer start` works in repo clone
- [ ] Verify no `.mise.toml` auto-activation when cd'ing into the sample directory
- [ ] `bash -n testing/manual-test.sh` passes syntax check
- [ ] CI server tests pass (no STATIC_DIR change affects CI since docker-compose sets paths via volume mounts)