### PR TITLE
Improve EwCS README for Stripe CLI users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 _Explore different ways to accept payments on the web with Stripe._
 
 > [!TIP]
+> **Downloaded via `stripe samples create`?** Your server is in `./server/` and your client is in `./client/`. Install dependencies and start (e.g. `cd server && npm install && npm start` for Node). If the page doesn't load or you see errors about missing keys, make sure you ran `stripe login` before `stripe samples create` — the CLI needs this to write `server/.env`.
+
+> [!TIP]
 > **Starting a new integration?** Stripe recommends building on the [Checkout Sessions API](https://docs.stripe.com/payments/checkout) — choose a [Stripe-hosted page](./prebuilt-checkout-page) for simplicity or [Elements with Checkout Sessions](./elements-with-checkout-sessions) for full design control.
 
 ## Choose your integration
@@ -132,13 +135,26 @@ Build a fully custom checkout using individual Stripe Elements and the Payment I
 
 ## Quick start
 
+### Option A: Stripe CLI (recommended)
+
 The recommended way to use this Stripe Sample is with the [Stripe CLI](https://stripe.com/docs/stripe-cli#install):
 
 ```sh
+stripe login
 stripe samples create accept-a-payment
 ```
 
-You can also clone the repository directly. See the individual READMEs for setup instructions:
+Then see the integration's README for how to install dependencies and start the server.
+
+> **Important:** You must run `stripe login` before `stripe samples create`. The CLI uses your login to configure API keys and file paths in `server/.env`.
+
+### Option B: Clone the repo
+
+```sh
+git clone https://github.com/stripe-samples/accept-a-payment
+```
+
+See the individual integration READMEs for setup:
 
 **Checkout Sessions API** (recommended):
 - [Prebuilt Checkout page](./prebuilt-checkout-page/README.md) — Stripe-hosted page

--- a/elements-with-checkout-sessions/README.md
+++ b/elements-with-checkout-sessions/README.md
@@ -54,7 +54,7 @@ the payment form.
 | `STRIPE_SECRET_KEY` | Your secret key (`sk_test_...`) | Set by CLI | *required* |
 | `STRIPE_WEBHOOK_SECRET` | Webhook secret (`whsec_...`) | Set by CLI | *optional* |
 | `STATIC_DIR` | Path to client files | `../client` | `../../client/html` |
-| `DOMAIN` | Base URL for return URLs | Set by CLI | `http://localhost:4242` (HTML) or `:3000` (React) |
+| `DOMAIN` | Base URL for return URLs | `http://localhost:4242` (HTML) or `:3000` (React) | `http://localhost:4242` (HTML) or `:3000` (React) |
 | `PORT` | Server port | `4242` | `4242` |
 
 ## How to run

--- a/elements-with-checkout-sessions/README.md
+++ b/elements-with-checkout-sessions/README.md
@@ -59,52 +59,15 @@ the payment form.
 
 ## How to run
 
-### Stripe CLI
-
-If you used `stripe samples create accept-a-payment`, `cd server` and see your language's README:
+Pick your server language:
 
 [Node](server/node/README.md) | [Python](server/python/README.md) | [Ruby](server/ruby/README.md) | [PHP](server/php/README.md) | [Java](server/java/README.md) | [Go](server/go/README.md) | [.NET](server/dotnet/README.md)
 
-> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI uses your login to write `server/.env` with API keys and `STATIC_DIR=../client`. If `.env` is missing, either re-run with login or create it manually:
+Each README covers both setup methods (Stripe CLI and cloning) and both clients (HTML and React).
+
+> **Downloaded via `stripe samples create` and something's not working?** Make sure you ran `stripe login` first. The CLI needs this to write `server/.env`. If `.env` is missing, create it manually:
 > ```
 > STRIPE_PUBLISHABLE_KEY=pk_test_...
 > STRIPE_SECRET_KEY=sk_test_...
 > STATIC_DIR=../client
 > ```
-
-### Cloned from GitHub
-
-Pick a server language and follow its README:
-
-[Node](server/node/README.md) | [Python](server/python/README.md) | [Ruby](server/ruby/README.md) | [PHP](server/php/README.md) | [Java](server/java/README.md) | [Go](server/go/README.md) | [.NET](server/dotnet/README.md)
-
-## Clients
-
-### HTML
-
-The HTML client lives in `client/html/`. Every server is configured
-to serve this directory as static files by default (via the `STATIC_DIR`
-environment variable). No separate build step is needed.
-
-### React
-
-The React client uses Vite and proxies API requests to the backend:
-
-```bash
-cd client/react-cra
-npm install
-npm start
-```
-
-The dev server starts on port 3000 and proxies `/api` requests to
-`http://127.0.0.1:4242`. Navigate to
-[http://localhost:3000](http://localhost:3000) to see the payment form.
-Make sure a backend server is running on port 4242 first.
-
-**Important:** Set `DOMAIN` to your Vite dev server URL so Stripe
-redirects back to the React app after payment:
-
-```bash
-# In your server's .env
-DOMAIN=http://localhost:3000
-```

--- a/elements-with-checkout-sessions/README.md
+++ b/elements-with-checkout-sessions/README.md
@@ -54,10 +54,8 @@ the payment form.
 | `STRIPE_SECRET_KEY` | Your secret key (`sk_test_...`) | Set by CLI | *required* |
 | `STRIPE_WEBHOOK_SECRET` | Webhook secret (`whsec_...`) | Set by CLI | *optional* |
 | `STATIC_DIR` | Path to client files | `../client` | `../../client/html` |
-| `DOMAIN` | Base URL for return URLs | `http://localhost:4242` | `http://localhost:4242` |
+| `DOMAIN` | Base URL for return URLs | Set by CLI | `http://localhost:4242` (HTML) or `:3000` (React) |
 | `PORT` | Server port | `4242` | `4242` |
-
-> For the React client, set `DOMAIN=http://localhost:3000`.
 
 ## How to run
 

--- a/elements-with-checkout-sessions/README.md
+++ b/elements-with-checkout-sessions/README.md
@@ -45,96 +45,40 @@ the payment form.
   - **Java** >= 17 with Maven
   - **Go** >= 1.22
   - **.NET** >= 9.0
-- Or install all runtimes automatically with [mise](https://mise.jdx.dev): `mise install`
 
 ## Environment variables
 
-| Variable | Description | Default |
-|---|---|---|
-| `STRIPE_SECRET_KEY` | Your Stripe secret key (`sk_test_...`) | *required* |
-| `STRIPE_PUBLISHABLE_KEY` | Your Stripe publishable key (`pk_test_...`) | *required* |
-| `STRIPE_WEBHOOK_SECRET` | Your Stripe webhook secret (`whsec_...`) | *optional* |
-| `STATIC_DIR` | Path to the static files directory | `../../client/html` |
-| `DOMAIN` | Base URL for return URLs | `http://localhost:${PORT}` |
-| `PORT` | Port the server listens on | `4242` |
+| Variable | Description | CLI | Clone |
+|---|---|---|---|
+| `STRIPE_PUBLISHABLE_KEY` | Your publishable key (`pk_test_...`) | Set by CLI | *required* |
+| `STRIPE_SECRET_KEY` | Your secret key (`sk_test_...`) | Set by CLI | *required* |
+| `STRIPE_WEBHOOK_SECRET` | Webhook secret (`whsec_...`) | Set by CLI | *optional* |
+| `STATIC_DIR` | Path to client files | `../client` | `../../client/html` |
+| `DOMAIN` | Base URL for return URLs | `http://localhost:4242` | `http://localhost:4242` |
+| `PORT` | Server port | `4242` | `4242` |
+
+> For the React client, set `DOMAIN=http://localhost:3000`.
 
 ## How to run
 
-### 1. Set up environment variables
+### Stripe CLI
 
-Copy the `.env.example` file into the server directory you plan to use and
-fill in your Stripe API keys:
+If you used `stripe samples create accept-a-payment`, `cd server` and see your language's README:
 
-```bash
-cp .env.example server/node/.env
-# Edit server/node/.env and add your keys
-```
+[Node](server/node/README.md) | [Python](server/python/README.md) | [Ruby](server/ruby/README.md) | [PHP](server/php/README.md) | [Java](server/java/README.md) | [Go](server/go/README.md) | [.NET](server/dotnet/README.md)
 
-### 2. Pick a server and start it
+> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI uses your login to write `server/.env` with API keys and `STATIC_DIR=../client`. If `.env` is missing, either re-run with login or create it manually:
+> ```
+> STRIPE_PUBLISHABLE_KEY=pk_test_...
+> STRIPE_SECRET_KEY=sk_test_...
+> STATIC_DIR=../client
+> ```
 
-#### Node
+### Cloned from GitHub
 
-```bash
-cd server/node
-cp ../../.env.example .env  # add your keys
-npm install
-npm start
-```
+Pick a server language and follow its README:
 
-#### Python
-
-```bash
-cd server/python
-cp ../../.env.example .env  # add your keys
-pip install -r requirements.txt
-python server.py
-```
-
-#### Ruby
-
-```bash
-cd server/ruby
-cp ../../.env.example .env  # add your keys
-bundle install
-ruby server.rb
-```
-
-#### PHP
-
-```bash
-cd server/php
-cp ../../.env.example .env  # add your keys
-composer install
-php -S localhost:4242 router.php
-```
-
-#### Java
-
-```bash
-cd server/java
-cp ../../.env.example .env  # add your keys
-mvn compile exec:java
-```
-
-#### Go
-
-```bash
-cd server/go
-cp ../../.env.example .env  # add your keys
-go run server.go
-```
-
-#### .NET
-
-```bash
-cd server/dotnet
-cp ../../.env.example .env  # add your keys
-dotnet run
-```
-
-### 3. Open in the browser
-
-Visit [http://localhost:4242](http://localhost:4242) to see the payment form.
+[Node](server/node/README.md) | [Python](server/python/README.md) | [Ruby](server/ruby/README.md) | [PHP](server/php/README.md) | [Java](server/java/README.md) | [Go](server/go/README.md) | [.NET](server/dotnet/README.md)
 
 ## Clients
 

--- a/elements-with-checkout-sessions/server/README.md
+++ b/elements-with-checkout-sessions/server/README.md
@@ -1,0 +1,9 @@
+# Server implementations
+
+- [Node (Express)](node/README.md)
+- [Python (Flask)](python/README.md)
+- [Ruby (Sinatra)](ruby/README.md)
+- [PHP](php/README.md)
+- [Java (Spark)](java/README.md)
+- [Go](go/README.md)
+- [.NET (ASP.NET Core)](dotnet/README.md)

--- a/elements-with-checkout-sessions/server/dotnet/README.md
+++ b/elements-with-checkout-sessions/server/dotnet/README.md
@@ -1,0 +1,71 @@
+# Elements with Checkout Sessions — .NET
+
+An [ASP.NET Core](https://dotnet.microsoft.com/apps/aspnet) server implementation.
+
+## Requirements
+
+- .NET >= 9.0
+
+## How to run
+
+### Stripe CLI
+
+If you downloaded with `stripe samples create` (and ran `stripe login` first):
+
+```bash
+dotnet run
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+
+```bash
+cd ../client
+npm install
+npm start
+```
+
+Open http://localhost:3000.
+
+---
+
+> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI needs this to write `.env`. If it's missing, create it manually:
+> ```
+> STRIPE_PUBLISHABLE_KEY=pk_test_...
+> STRIPE_SECRET_KEY=sk_test_...
+> STATIC_DIR=../client
+> ```
+> For React, also add `DOMAIN=http://localhost:3000`.
+
+### Cloned repo
+
+```bash
+cp ../../.env.example .env
+```
+
+Edit `.env` — add your [test API keys](https://dashboard.stripe.com/test/apikeys). Confirm `STATIC_DIR=../../client/html` (already set by the template).
+
+```bash
+dotnet run
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Set `DOMAIN=http://localhost:3000` in your `.env`, then start the React dev server:
+
+```bash
+cd ../../client/react-cra
+npm install
+npm start
+```
+
+Open http://localhost:3000.

--- a/elements-with-checkout-sessions/server/dotnet/README.md
+++ b/elements-with-checkout-sessions/server/dotnet/README.md
@@ -10,7 +10,7 @@ An [ASP.NET Core](https://dotnet.microsoft.com/apps/aspnet) server implementatio
 
 ### Stripe CLI
 
-If you downloaded with `stripe samples create` (and ran `stripe login` first):
+If you downloaded with `stripe samples create`:
 
 ```bash
 dotnet run
@@ -22,7 +22,7 @@ Open http://localhost:4242.
 
 #### React client
 
-Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+Check that `DOMAIN=http://localhost:3000` is in your `.env`, then start the React dev server:
 
 ```bash
 cd ../client

--- a/elements-with-checkout-sessions/server/go/README.md
+++ b/elements-with-checkout-sessions/server/go/README.md
@@ -10,7 +10,7 @@ A Go standard library server implementation.
 
 ### Stripe CLI
 
-If you downloaded with `stripe samples create` (and ran `stripe login` first):
+If you downloaded with `stripe samples create`:
 
 ```bash
 go run server.go
@@ -22,7 +22,7 @@ Open http://localhost:4242.
 
 #### React client
 
-Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+Check that `DOMAIN=http://localhost:3000` is in your `.env`, then start the React dev server:
 
 ```bash
 cd ../client

--- a/elements-with-checkout-sessions/server/go/README.md
+++ b/elements-with-checkout-sessions/server/go/README.md
@@ -1,0 +1,71 @@
+# Elements with Checkout Sessions — Go
+
+A Go standard library server implementation.
+
+## Requirements
+
+- Go >= 1.22
+
+## How to run
+
+### Stripe CLI
+
+If you downloaded with `stripe samples create` (and ran `stripe login` first):
+
+```bash
+go run server.go
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+
+```bash
+cd ../client
+npm install
+npm start
+```
+
+Open http://localhost:3000.
+
+---
+
+> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI needs this to write `.env`. If it's missing, create it manually:
+> ```
+> STRIPE_PUBLISHABLE_KEY=pk_test_...
+> STRIPE_SECRET_KEY=sk_test_...
+> STATIC_DIR=../client
+> ```
+> For React, also add `DOMAIN=http://localhost:3000`.
+
+### Cloned repo
+
+```bash
+cp ../../.env.example .env
+```
+
+Edit `.env` — add your [test API keys](https://dashboard.stripe.com/test/apikeys). Confirm `STATIC_DIR=../../client/html` (already set by the template).
+
+```bash
+go run server.go
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Set `DOMAIN=http://localhost:3000` in your `.env`, then start the React dev server:
+
+```bash
+cd ../../client/react-cra
+npm install
+npm start
+```
+
+Open http://localhost:3000.

--- a/elements-with-checkout-sessions/server/java/README.md
+++ b/elements-with-checkout-sessions/server/java/README.md
@@ -1,0 +1,71 @@
+# Elements with Checkout Sessions — Java
+
+A [Spark](http://sparkjava.com/) server implementation.
+
+## Requirements
+
+- Java >= 17 with Maven
+
+## How to run
+
+### Stripe CLI
+
+If you downloaded with `stripe samples create` (and ran `stripe login` first):
+
+```bash
+mvn compile exec:java
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+
+```bash
+cd ../client
+npm install
+npm start
+```
+
+Open http://localhost:3000.
+
+---
+
+> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI needs this to write `.env`. If it's missing, create it manually:
+> ```
+> STRIPE_PUBLISHABLE_KEY=pk_test_...
+> STRIPE_SECRET_KEY=sk_test_...
+> STATIC_DIR=../client
+> ```
+> For React, also add `DOMAIN=http://localhost:3000`.
+
+### Cloned repo
+
+```bash
+cp ../../.env.example .env
+```
+
+Edit `.env` — add your [test API keys](https://dashboard.stripe.com/test/apikeys). Confirm `STATIC_DIR=../../client/html` (already set by the template).
+
+```bash
+mvn compile exec:java
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Set `DOMAIN=http://localhost:3000` in your `.env`, then start the React dev server:
+
+```bash
+cd ../../client/react-cra
+npm install
+npm start
+```
+
+Open http://localhost:3000.

--- a/elements-with-checkout-sessions/server/java/README.md
+++ b/elements-with-checkout-sessions/server/java/README.md
@@ -10,7 +10,7 @@ A [Spark](http://sparkjava.com/) server implementation.
 
 ### Stripe CLI
 
-If you downloaded with `stripe samples create` (and ran `stripe login` first):
+If you downloaded with `stripe samples create`:
 
 ```bash
 mvn compile exec:java
@@ -22,7 +22,7 @@ Open http://localhost:4242.
 
 #### React client
 
-Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+Check that `DOMAIN=http://localhost:3000` is in your `.env`, then start the React dev server:
 
 ```bash
 cd ../client

--- a/elements-with-checkout-sessions/server/node/README.md
+++ b/elements-with-checkout-sessions/server/node/README.md
@@ -1,0 +1,73 @@
+# Elements with Checkout Sessions — Node
+
+An [Express](http://expressjs.com) server implementation.
+
+## Requirements
+
+- Node >= 18
+
+## How to run
+
+### Stripe CLI
+
+If you downloaded with `stripe samples create` (and ran `stripe login` first):
+
+```bash
+npm install
+npm start
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+
+```bash
+cd ../client
+npm install
+npm start
+```
+
+Open http://localhost:3000.
+
+---
+
+> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI needs this to write `.env`. If it's missing, create it manually:
+> ```
+> STRIPE_PUBLISHABLE_KEY=pk_test_...
+> STRIPE_SECRET_KEY=sk_test_...
+> STATIC_DIR=../client
+> ```
+> For React, also add `DOMAIN=http://localhost:3000`.
+
+### Cloned repo
+
+```bash
+cp ../../.env.example .env
+```
+
+Edit `.env` — add your [test API keys](https://dashboard.stripe.com/test/apikeys). Confirm `STATIC_DIR=../../client/html` (already set by the template).
+
+```bash
+npm install
+npm start
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Set `DOMAIN=http://localhost:3000` in your `.env`, then start the React dev server:
+
+```bash
+cd ../../client/react-cra
+npm install
+npm start
+```
+
+Open http://localhost:3000.

--- a/elements-with-checkout-sessions/server/node/README.md
+++ b/elements-with-checkout-sessions/server/node/README.md
@@ -10,7 +10,7 @@ An [Express](http://expressjs.com) server implementation.
 
 ### Stripe CLI
 
-If you downloaded with `stripe samples create` (and ran `stripe login` first):
+If you downloaded with `stripe samples create`:
 
 ```bash
 npm install
@@ -23,7 +23,7 @@ Open http://localhost:4242.
 
 #### React client
 
-Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+Check that `DOMAIN=http://localhost:3000` is in your `.env`, then start the React dev server:
 
 ```bash
 cd ../client

--- a/elements-with-checkout-sessions/server/php/README.md
+++ b/elements-with-checkout-sessions/server/php/README.md
@@ -10,7 +10,7 @@ A PHP built-in server implementation.
 
 ### Stripe CLI
 
-If you downloaded with `stripe samples create` (and ran `stripe login` first):
+If you downloaded with `stripe samples create`:
 
 ```bash
 composer install
@@ -23,7 +23,7 @@ Open http://localhost:4242.
 
 #### React client
 
-Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+Check that `DOMAIN=http://localhost:3000` is in your `.env`, then start the React dev server:
 
 ```bash
 cd ../client

--- a/elements-with-checkout-sessions/server/php/README.md
+++ b/elements-with-checkout-sessions/server/php/README.md
@@ -1,0 +1,73 @@
+# Elements with Checkout Sessions — PHP
+
+A PHP built-in server implementation.
+
+## Requirements
+
+- PHP >= 8.2 with Composer
+
+## How to run
+
+### Stripe CLI
+
+If you downloaded with `stripe samples create` (and ran `stripe login` first):
+
+```bash
+composer install
+composer start
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+
+```bash
+cd ../client
+npm install
+npm start
+```
+
+Open http://localhost:3000.
+
+---
+
+> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI needs this to write `.env`. If it's missing, create it manually:
+> ```
+> STRIPE_PUBLISHABLE_KEY=pk_test_...
+> STRIPE_SECRET_KEY=sk_test_...
+> STATIC_DIR=../client
+> ```
+> For React, also add `DOMAIN=http://localhost:3000`.
+
+### Cloned repo
+
+```bash
+cp ../../.env.example .env
+```
+
+Edit `.env` — add your [test API keys](https://dashboard.stripe.com/test/apikeys). Confirm `STATIC_DIR=../../client/html` (already set by the template).
+
+```bash
+composer install
+composer start
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Set `DOMAIN=http://localhost:3000` in your `.env`, then start the React dev server:
+
+```bash
+cd ../../client/react-cra
+npm install
+npm start
+```
+
+Open http://localhost:3000.

--- a/elements-with-checkout-sessions/server/python/README.md
+++ b/elements-with-checkout-sessions/server/python/README.md
@@ -1,0 +1,73 @@
+# Elements with Checkout Sessions — Python
+
+A [Flask](https://flask.palletsprojects.com/) server implementation.
+
+## Requirements
+
+- Python >= 3.12
+
+## How to run
+
+### Stripe CLI
+
+If you downloaded with `stripe samples create` (and ran `stripe login` first):
+
+```bash
+pip install -r requirements.txt
+python server.py
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+
+```bash
+cd ../client
+npm install
+npm start
+```
+
+Open http://localhost:3000.
+
+---
+
+> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI needs this to write `.env`. If it's missing, create it manually:
+> ```
+> STRIPE_PUBLISHABLE_KEY=pk_test_...
+> STRIPE_SECRET_KEY=sk_test_...
+> STATIC_DIR=../client
+> ```
+> For React, also add `DOMAIN=http://localhost:3000`.
+
+### Cloned repo
+
+```bash
+cp ../../.env.example .env
+```
+
+Edit `.env` — add your [test API keys](https://dashboard.stripe.com/test/apikeys). Confirm `STATIC_DIR=../../client/html` (already set by the template).
+
+```bash
+pip install -r requirements.txt
+python server.py
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Set `DOMAIN=http://localhost:3000` in your `.env`, then start the React dev server:
+
+```bash
+cd ../../client/react-cra
+npm install
+npm start
+```
+
+Open http://localhost:3000.

--- a/elements-with-checkout-sessions/server/python/README.md
+++ b/elements-with-checkout-sessions/server/python/README.md
@@ -10,7 +10,7 @@ A [Flask](https://flask.palletsprojects.com/) server implementation.
 
 ### Stripe CLI
 
-If you downloaded with `stripe samples create` (and ran `stripe login` first):
+If you downloaded with `stripe samples create`:
 
 ```bash
 pip install -r requirements.txt
@@ -23,7 +23,7 @@ Open http://localhost:4242.
 
 #### React client
 
-Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+Check that `DOMAIN=http://localhost:3000` is in your `.env`, then start the React dev server:
 
 ```bash
 cd ../client

--- a/elements-with-checkout-sessions/server/ruby/README.md
+++ b/elements-with-checkout-sessions/server/ruby/README.md
@@ -1,0 +1,73 @@
+# Elements with Checkout Sessions — Ruby
+
+A [Sinatra](http://sinatrarb.com/) server implementation.
+
+## Requirements
+
+- Ruby >= 3.3
+
+## How to run
+
+### Stripe CLI
+
+If you downloaded with `stripe samples create` (and ran `stripe login` first):
+
+```bash
+bundle install
+ruby server.rb
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+
+```bash
+cd ../client
+npm install
+npm start
+```
+
+Open http://localhost:3000.
+
+---
+
+> **Not working?** Make sure you ran `stripe login` before `stripe samples create`. The CLI needs this to write `.env`. If it's missing, create it manually:
+> ```
+> STRIPE_PUBLISHABLE_KEY=pk_test_...
+> STRIPE_SECRET_KEY=sk_test_...
+> STATIC_DIR=../client
+> ```
+> For React, also add `DOMAIN=http://localhost:3000`.
+
+### Cloned repo
+
+```bash
+cp ../../.env.example .env
+```
+
+Edit `.env` — add your [test API keys](https://dashboard.stripe.com/test/apikeys). Confirm `STATIC_DIR=../../client/html` (already set by the template).
+
+```bash
+bundle install
+ruby server.rb
+```
+
+#### HTML client
+
+Open http://localhost:4242.
+
+#### React client
+
+Set `DOMAIN=http://localhost:3000` in your `.env`, then start the React dev server:
+
+```bash
+cd ../../client/react-cra
+npm install
+npm start
+```
+
+Open http://localhost:3000.

--- a/elements-with-checkout-sessions/server/ruby/README.md
+++ b/elements-with-checkout-sessions/server/ruby/README.md
@@ -10,7 +10,7 @@ A [Sinatra](http://sinatrarb.com/) server implementation.
 
 ### Stripe CLI
 
-If you downloaded with `stripe samples create` (and ran `stripe login` first):
+If you downloaded with `stripe samples create`:
 
 ```bash
 bundle install
@@ -23,7 +23,7 @@ Open http://localhost:4242.
 
 #### React client
 
-Add `DOMAIN=http://localhost:3000` to your `.env`, then start the React dev server:
+Check that `DOMAIN=http://localhost:3000` is in your `.env`, then start the React dev server:
 
 ```bash
 cd ../client


### PR DESCRIPTION
## Summary

<img width="1022" height="708" alt="image" src="https://github.com/user-attachments/assets/d7eacf4b-984d-47c8-88bd-2dd420ea4404" />


- Separates "How to run" into **Stripe CLI** vs **Clone** paths so users immediately see the right instructions
- Adds troubleshooting for the common case where `stripe login` was skipped before `stripe samples create` (CLI can't write `server/.env` without auth)
- Restructures root README Quick start into Option A (CLI) and Option B (Clone), with `stripe login` as the first step
- Adds per-language server READMEs which are visible for stripe CLI users. 

## Context

A user reported confusion after downloading via `stripe samples create` without running `stripe login` first. The CLI needs auth to write `server/.env` with API keys and `STATIC_DIR=../client`. Without it, the server can't find static files or call Stripe. 

## Test plan
No code changes, existing tests unaffected