### PR TITLE
fix: use e.message instead of e.error.message in generic rescue

### DIFF
--- a/custom-payment-flow/server/ruby/server.rb
+++ b/custom-payment-flow/server/ruby/server.rb
@@ -87,7 +87,7 @@ post '/create-payment-intent' do
   rescue => e
     halt 500,
       { 'Content-Type' => 'application/json' },
-      { error: { message: e.error.message }}.to_json
+      { error: { message: e.message }}.to_json
   end
 
   # This API endpoint renders back JSON with the client_secret for the payment


### PR DESCRIPTION
The generic rescue block was calling e.error.message, which only exists on Stripe::StripeError. For any standard Ruby exception this raises NoMethodError, crashing the error handler itself. Changed to e.message.