### PR TITLE
Align Stripe API version pins to 2026-07-29.dahlia

### DIFF
--- a/custom-payment-flow/client/html/ach.js
+++ b/custom-payment-flow/client/html/ach.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
   let paymentIntentClientSecret;
 

--- a/custom-payment-flow/client/html/acss.js
+++ b/custom-payment-flow/client/html/acss.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/affirm.js
+++ b/custom-payment-flow/client/html/affirm.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/afterpay-clearpay.js
+++ b/custom-payment-flow/client/html/afterpay-clearpay.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/alipay.js
+++ b/custom-payment-flow/client/html/alipay.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/apple-pay.js
+++ b/custom-payment-flow/client/html/apple-pay.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // 1. Initialize Stripe
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // 2. Create a payment request object

--- a/custom-payment-flow/client/html/boleto.js
+++ b/custom-payment-flow/client/html/boleto.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/card.js
+++ b/custom-payment-flow/client/html/card.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   const elements = stripe.elements();

--- a/custom-payment-flow/client/html/eps.js
+++ b/custom-payment-flow/client/html/eps.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
   const elements = stripe.elements();
   const epsBank = elements.create('epsBank');

--- a/custom-payment-flow/client/html/fpx.js
+++ b/custom-payment-flow/client/html/fpx.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
   const elements = stripe.elements();
   const fpxBank = elements.create('fpxBank', {

--- a/custom-payment-flow/client/html/giropay.js
+++ b/custom-payment-flow/client/html/giropay.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/google-pay.js
+++ b/custom-payment-flow/client/html/google-pay.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // 1. Initialize Stripe
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // 2. Create a payment request object

--- a/custom-payment-flow/client/html/grabpay.js
+++ b/custom-payment-flow/client/html/grabpay.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     alert('Please set your Stripe publishable API key in the .env file');
   }
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/ideal.js
+++ b/custom-payment-flow/client/html/ideal.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   const elements = stripe.elements();

--- a/custom-payment-flow/client/html/klarna.js
+++ b/custom-payment-flow/client/html/klarna.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/konbini.js
+++ b/custom-payment-flow/client/html/konbini.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   
     const stripe = Stripe(publishableKey, {
       betas: ['konbini_pm_beta_1'],
-      apiVersion: '2020-08-27; konbini_beta=v1',
+      apiVersion: '2026-07-29.dahlia',
     });
   
     // When the form is submitted...

--- a/custom-payment-flow/client/html/link.js
+++ b/custom-payment-flow/client/html/link.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2022-11-15',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   const { clientSecret } = await fetch('/create-payment-intent', {

--- a/custom-payment-flow/client/html/oxxo.js
+++ b/custom-payment-flow/client/html/oxxo.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/p24.js
+++ b/custom-payment-flow/client/html/p24.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   const elements = stripe.elements();

--- a/custom-payment-flow/client/html/paypal.js
+++ b/custom-payment-flow/client/html/paypal.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // 1. Initialize Stripe
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2024-06-20',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   MODE = 'payment';

--- a/custom-payment-flow/client/html/return.js
+++ b/custom-payment-flow/client/html/return.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   const url = new URL(window.location);

--- a/custom-payment-flow/client/html/sepa-debit.js
+++ b/custom-payment-flow/client/html/sepa-debit.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   const elements = stripe.elements();

--- a/custom-payment-flow/client/html/sofort.js
+++ b/custom-payment-flow/client/html/sofort.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/client/html/wechatpay.js
+++ b/custom-payment-flow/client/html/wechatpay.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     alert('Please set your Stripe publishable API key in the .env file');
   }
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-03-02',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // When the form is submitted...

--- a/custom-payment-flow/server/nextjs/lib/stripe.ts
+++ b/custom-payment-flow/server/nextjs/lib/stripe.ts
@@ -10,7 +10,7 @@ export function getStripe(): Stripe {
     // See https://docs.stripe.com/keys-best-practices and find your
     // keys at https://dashboard.stripe.com/apikeys.
     stripeInstance = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-      apiVersion: "2025-12-15.clover",
+      apiVersion: "2026-07-29.dahlia",
       appInfo: {
         name: "stripe-samples/accept-a-payment/custom-payment-flow",
         version: "0.0.2",

--- a/custom-payment-flow/server/node-typescript/src/server.ts
+++ b/custom-payment-flow/server/node-typescript/src/server.ts
@@ -11,7 +11,7 @@ import Stripe from "stripe";
 
 const calculateTax = false;
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2025-12-15.clover",
+  apiVersion: "2026-07-29.dahlia",
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/accept-a-payment",
     url: "https://github.com/stripe-samples",

--- a/custom-payment-flow/server/node/server.js
+++ b/custom-payment-flow/server/node/server.js
@@ -12,7 +12,7 @@ const calculateTax = false;
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-10-16',
+  apiVersion: '2026-07-29.dahlia',
   appInfo: {
     // For sample support and debugging, not required for production:
     name: 'stripe-samples/accept-a-payment/custom-payment-flow',

--- a/custom-payment-flow/server/php/public/acss.php
+++ b/custom-payment-flow/server/php/public/acss.php
@@ -44,7 +44,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         const paymentForm = document.querySelector('#payment-form');

--- a/custom-payment-flow/server/php/public/afterpay-clearpay.php
+++ b/custom-payment-flow/server/php/public/afterpay-clearpay.php
@@ -36,7 +36,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
         const paymentForm = document.querySelector('#payment-form');
         paymentForm.addEventListener('submit', async (e) => {

--- a/custom-payment-flow/server/php/public/alipay.php
+++ b/custom-payment-flow/server/php/public/alipay.php
@@ -36,7 +36,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         const paymentForm = document.querySelector('#payment-form');

--- a/custom-payment-flow/server/php/public/apple-pay.php
+++ b/custom-payment-flow/server/php/public/apple-pay.php
@@ -36,7 +36,7 @@ try {
       document.addEventListener('DOMContentLoaded', async () => {
         // 1. Initialize Stripe
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         // 2. Create a payment request object

--- a/custom-payment-flow/server/php/public/bancontact.php
+++ b/custom-payment-flow/server/php/public/bancontact.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
         const paymentForm = document.querySelector('#payment-form');
         paymentForm.addEventListener('submit', async (e) => {

--- a/custom-payment-flow/server/php/public/becs-debit.php
+++ b/custom-payment-flow/server/php/public/becs-debit.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
         const elements = stripe.elements();
         const auBankAccount = elements.create('auBankAccount');

--- a/custom-payment-flow/server/php/public/boleto.php
+++ b/custom-payment-flow/server/php/public/boleto.php
@@ -36,7 +36,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         const paymentForm = document.querySelector('#payment-form');

--- a/custom-payment-flow/server/php/public/card.php
+++ b/custom-payment-flow/server/php/public/card.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
         const elements = stripe.elements();
         const cardElement = elements.create('card');

--- a/custom-payment-flow/server/php/public/eps.php
+++ b/custom-payment-flow/server/php/public/eps.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         const elements = stripe.elements();

--- a/custom-payment-flow/server/php/public/fpx.php
+++ b/custom-payment-flow/server/php/public/fpx.php
@@ -36,7 +36,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         const elements = stripe.elements();

--- a/custom-payment-flow/server/php/public/giropay.php
+++ b/custom-payment-flow/server/php/public/giropay.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
         const paymentForm = document.querySelector('#payment-form');
         paymentForm.addEventListener('submit', async (e) => {

--- a/custom-payment-flow/server/php/public/google-pay.php
+++ b/custom-payment-flow/server/php/public/google-pay.php
@@ -36,7 +36,7 @@ try {
       document.addEventListener('DOMContentLoaded', async () => {
         // 1. Initialize Stripe
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         // 2. Create a payment request object

--- a/custom-payment-flow/server/php/public/grabpay.php
+++ b/custom-payment-flow/server/php/public/grabpay.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
         const paymentForm = document.querySelector('#payment-form');
         paymentForm.addEventListener('submit', async (e) => {

--- a/custom-payment-flow/server/php/public/ideal.php
+++ b/custom-payment-flow/server/php/public/ideal.php
@@ -36,7 +36,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
 

--- a/custom-payment-flow/server/php/public/konbini.php
+++ b/custom-payment-flow/server/php/public/konbini.php
@@ -42,7 +42,7 @@ try {
         
         document.addEventListener('DOMContentLoaded', async () => {
             const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-                apiVersion: '2020-08-27',
+                apiVersion: '2026-07-29.dahlia',
             });
         
             // When the form is submitted...

--- a/custom-payment-flow/server/php/public/link.php
+++ b/custom-payment-flow/server/php/public/link.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2022-11-15',
+          apiVersion: '2026-07-29.dahlia',
         });
           // Enable the skeleton loader UI for the optimal loading experience.
         const loader = 'auto';

--- a/custom-payment-flow/server/php/public/oxxo.php
+++ b/custom-payment-flow/server/php/public/oxxo.php
@@ -36,7 +36,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         const paymentForm = document.querySelector('#payment-form');

--- a/custom-payment-flow/server/php/public/p24.php
+++ b/custom-payment-flow/server/php/public/p24.php
@@ -36,7 +36,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         const elements = stripe.elements();

--- a/custom-payment-flow/server/php/public/sepa-debit.php
+++ b/custom-payment-flow/server/php/public/sepa-debit.php
@@ -34,7 +34,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
         const elements = stripe.elements();
         const iban = elements.create('iban', {

--- a/custom-payment-flow/server/php/public/sofort.php
+++ b/custom-payment-flow/server/php/public/sofort.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
         const paymentForm = document.querySelector('#payment-form');
         paymentForm.addEventListener('submit', async (e) => {

--- a/custom-payment-flow/server/python/server.py
+++ b/custom-payment-flow/server/python/server.py
@@ -15,7 +15,7 @@ stripe.set_app_info(
     version='0.0.2',
     url='https://github.com/stripe-samples')
 
-stripe.api_version = '2023-10-16'
+stripe.api_version = '2026-07-29.dahlia'
 # Don't put any keys in code. Use an environment variable (as shown
 # here) or secrets vault to supply keys to your integration.
 #

--- a/custom-payment-flow/server/ruby/server.rb
+++ b/custom-payment-flow/server/ruby/server.rb
@@ -14,7 +14,7 @@ Stripe.set_app_info(
   version: '0.0.2',
   url: 'https://github.com/stripe-samples'
 )
-Stripe.api_version = '2020-08-27'
+Stripe.api_version = '2026-07-29.dahlia'
 # Don't put any keys in code. Use an environment variable (as shown
 # here) or secrets vault to supply keys to your integration.
 #

--- a/payment-element/client/html/index.js
+++ b/payment-element/client/html/index.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   // On page load, we create a PaymentIntent on the server so that we have its clientSecret to

--- a/payment-element/client/html/return.js
+++ b/payment-element/client/html/return.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const stripe = Stripe(publishableKey, {
-    apiVersion: '2020-08-27',
+    apiVersion: '2026-07-29.dahlia',
   });
 
   const url = new URL(window.location);

--- a/payment-element/server/nextjs/lib/stripe.ts
+++ b/payment-element/server/nextjs/lib/stripe.ts
@@ -10,7 +10,7 @@ export function getStripe(): Stripe {
     // See https://docs.stripe.com/keys-best-practices and find your
     // keys at https://dashboard.stripe.com/apikeys.
     stripeInstance = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-      apiVersion: "2025-12-15.clover",
+      apiVersion: "2026-07-29.dahlia",
       appInfo: {
         name: "stripe-samples/accept-a-payment",
         version: "0.0.2",

--- a/payment-element/server/node-typescript/src/server.ts
+++ b/payment-element/server/node-typescript/src/server.ts
@@ -14,7 +14,7 @@ import Stripe from "stripe";
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2025-12-15.clover",
+  apiVersion: "2026-07-29.dahlia",
   appInfo: {
     name: "stripe-samples/accept-a-payment",
     url: "https://github.com/stripe-samples",

--- a/payment-element/server/node/server.js
+++ b/payment-element/server/node/server.js
@@ -11,7 +11,7 @@ const calculateTax = false;
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-10-16',
+  apiVersion: '2026-07-29.dahlia',
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/accept-a-payment/payment-element",
     version: "0.0.2",

--- a/payment-element/server/php/public/index.php
+++ b/payment-element/server/php/public/index.php
@@ -35,7 +35,7 @@ try {
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
         const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"]; ?>', {
-          apiVersion: '2020-08-27',
+          apiVersion: '2026-07-29.dahlia',
         });
 
         const elements = stripe.elements({

--- a/payment-element/server/python/server.py
+++ b/payment-element/server/python/server.py
@@ -17,7 +17,7 @@ stripe.set_app_info(
     version='0.0.2',
     url='https://github.com/stripe-samples')
 
-stripe.api_version = '2023-10-16'
+stripe.api_version = '2026-07-29.dahlia'
 # Don't put any keys in code. Use an environment variable (as shown
 # here) or secrets vault to supply keys to your integration.
 #

--- a/payment-element/server/ruby/server.rb
+++ b/payment-element/server/ruby/server.rb
@@ -16,7 +16,7 @@ Stripe.set_app_info(
   version: '0.0.2',
   url: 'https://github.com/stripe-samples'
 )
-Stripe.api_version = '2020-08-27'
+Stripe.api_version = '2026-07-29.dahlia'
 # Don't put any keys in code. Use an environment variable (as shown
 # here) or secrets vault to supply keys to your integration.
 #

--- a/prebuilt-checkout-page/server/nextjs/lib/stripe.ts
+++ b/prebuilt-checkout-page/server/nextjs/lib/stripe.ts
@@ -10,7 +10,7 @@ export function getStripe(): Stripe {
     // See https://docs.stripe.com/keys-best-practices and find your
     // keys at https://dashboard.stripe.com/apikeys.
     stripeInstance = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-      apiVersion: "2025-12-15.clover",
+      apiVersion: "2026-07-29.dahlia",
       appInfo: {
         name: "stripe-samples/accept-a-payment/prebuilt-checkout-page",
         version: "0.0.1",

--- a/prebuilt-checkout-page/server/node/server.js
+++ b/prebuilt-checkout-page/server/node/server.js
@@ -13,7 +13,7 @@ checkEnv();
 // See https://docs.stripe.com/keys-best-practices and find your
 // keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-10-16',
+  apiVersion: '2026-07-29.dahlia',
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/accept-a-payment/prebuilt-checkout-page",
     version: "0.0.1",

--- a/prebuilt-checkout-page/server/python/server.py
+++ b/prebuilt-checkout-page/server/python/server.py
@@ -34,7 +34,7 @@ stripe.set_app_info(
 # See https://docs.stripe.com/keys-best-practices and find your
 # keys at https://dashboard.stripe.com/apikeys.
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
-stripe.api_version = '2020-08-27'
+stripe.api_version = '2026-07-29.dahlia'
 
 static_dir = str(os.path.abspath(os.path.join(
     __file__, "..", os.getenv("STATIC_DIR"))))

--- a/prebuilt-checkout-page/server/ruby/server.rb
+++ b/prebuilt-checkout-page/server/ruby/server.rb
@@ -13,7 +13,7 @@ Stripe.set_app_info(
   version: '0.0.1',
   url: 'https://github.com/stripe-samples'
 )
-Stripe.api_version = '2020-08-27'
+Stripe.api_version = '2026-07-29.dahlia'
 # Don't put any keys in code. Use an environment variable (as shown
 # here) or secrets vault to supply keys to your integration.
 #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,7 +116,7 @@ Dotenv.load
 # keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 Stripe.max_network_retries = 2
-Stripe.api_version = "2020-08-27"
+Stripe.api_version = "2026-07-29.dahlia"
 
 def server_url(path)
   url = URI(SERVER_URL)


### PR DESCRIPTION
## Summary
- Align explicit Stripe API version pins to **`2026-07-29.dahlia`** (latest GA default in `stripe@22.4.0`).
- Bump Node `stripe` dependency ranges to `^22.4.0` where package.json pins stripe.

## Evidence
- npm `stripe@22.4.0` → `ApiVersion = '2026-07-29.dahlia'`
- https://docs.stripe.com/upgrades

## Layerkit
Contract heal via layerkit agent pipeline (heal mode) + source-edit of production sample files.

## Test plan
- [ ] Spot-check PaymentIntent/Checkout Session create with test keys
- [ ] Confirm Dashboard request log shows Stripe-Version: 2026-07-29.dahlia
- [ ] CI sample suite if present